### PR TITLE
Reset tool selection when a re-trace replaces the polygons

### DIFF
--- a/frontend/src/app/trace/[id]/page.tsx
+++ b/frontend/src/app/trace/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
+import { usePolygonSelection } from '@/hooks/usePolygonSelection'
 import { Loader2, Copy, Upload, Download, Check, ChevronDown, ChevronRight, Pencil } from 'lucide-react'
 import { PaperCornerEditor } from '@/components/PaperCornerEditor'
 import { PolygonEditor } from '@/components/PolygonEditor'
@@ -83,7 +84,7 @@ export default function TracePage() {
   const [showPrompt, setShowPrompt] = useState(false)
   const [traceStatus, setTraceStatus] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
-  const [includedPolygons, setIncludedPolygons] = useState<Set<string>>(new Set())
+  const [includedPolygons, setIncludedPolygons] = usePolygonSelection(polygons)
   const [editingPolygonLabelId, setEditingPolygonLabelId] = useState<string | null>(null)
   const [hoveredPolygon, setHoveredPolygon] = useState<string | null>(null)
   const maskInputRef = useRef<HTMLInputElement>(null)

--- a/frontend/src/hooks/__tests__/usePolygonSelection.test.ts
+++ b/frontend/src/hooks/__tests__/usePolygonSelection.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePolygonSelection } from '../usePolygonSelection'
+
+function polys(...ids: string[]) {
+  return ids.map(id => ({ id }))
+}
+
+describe('usePolygonSelection', () => {
+  it('starts with nothing selected', () => {
+    const { result } = renderHook(() => usePolygonSelection(polys('a', 'b')))
+
+    expect(result.current[0].size).toBe(0)
+  })
+
+  it('keeps the ids the caller selects', () => {
+    const { result } = renderHook(() => usePolygonSelection(polys('a', 'b')))
+
+    act(() => result.current[1](new Set(['a', 'b'])))
+
+    expect([...result.current[0]]).toEqual(['a', 'b'])
+  })
+
+  it('drops the whole selection when a re-trace replaces every polygon', () => {
+    let current = polys('a', 'b', 'c')
+    const { result, rerender } = renderHook(() => usePolygonSelection(current))
+
+    act(() => result.current[1](new Set(['a', 'b', 'c'])))
+    expect(result.current[0].size).toBe(3)
+
+    // re-trace: the tracer mints fresh uuids, so no previous id survives
+    current = polys('d', 'e')
+    rerender()
+
+    expect(result.current[0].size).toBe(0)
+  })
+
+  it('never reports more selected than there are polygons', () => {
+    let current = polys('a', 'b', 'c')
+    const { result, rerender } = renderHook(() => usePolygonSelection(current))
+
+    act(() => result.current[1](new Set(['a', 'b', 'c'])))
+
+    current = polys('d', 'e')
+    rerender()
+
+    expect(result.current[0].size).toBeLessThanOrEqual(current.length)
+  })
+
+  it('keeps ids that survive a re-trace and drops the rest', () => {
+    let current = polys('a', 'b', 'c')
+    const { result, rerender } = renderHook(() => usePolygonSelection(current))
+
+    act(() => result.current[1](new Set(['a', 'c'])))
+
+    current = polys('a', 'z')
+    rerender()
+
+    expect([...result.current[0]]).toEqual(['a'])
+  })
+
+  it('drops a polygon deleted in the editor from the selection', () => {
+    let current = polys('a', 'b')
+    const { result, rerender } = renderHook(() => usePolygonSelection(current))
+
+    act(() => result.current[1](new Set(['a', 'b'])))
+
+    current = polys('a')
+    rerender()
+
+    expect([...result.current[0]]).toEqual(['a'])
+  })
+
+  it('collapses the selection when every polygon is gone', () => {
+    let current = polys('a', 'b')
+    const { result, rerender } = renderHook(() => usePolygonSelection(current))
+
+    act(() => result.current[1](new Set(['a', 'b'])))
+
+    current = polys()
+    rerender()
+
+    expect(result.current[0].size).toBe(0)
+  })
+
+  it('stays a subset of the polygons across repeated re-traces', () => {
+    let current = polys('a', 'b')
+    const { result, rerender } = renderHook(() => usePolygonSelection(current))
+
+    act(() => result.current[1](new Set(['a', 'b'])))
+
+    // first re-trace retires a
+    current = polys('b', 'c')
+    rerender()
+    expect([...result.current[0]]).toEqual(['b'])
+
+    // second re-trace retires b, and prunes from the raw selection rather than
+    // the already-pruned one
+    current = polys('c', 'd')
+    rerender()
+    expect(result.current[0].size).toBe(0)
+  })
+
+  it('returns the same set instance while the selection stays valid', () => {
+    let current = polys('a', 'b')
+    const { result, rerender } = renderHook(() => usePolygonSelection(current))
+
+    act(() => result.current[1](new Set(['a'])))
+    const first = result.current[0]
+
+    // fresh array with the same ids, so the memo recomputes rather than
+    // replaying its cached value and passing the assertion for free
+    current = polys('a', 'b')
+    rerender()
+
+    expect(result.current[0]).toBe(first)
+  })
+})

--- a/frontend/src/hooks/usePolygonSelection.ts
+++ b/frontend/src/hooks/usePolygonSelection.ts
@@ -1,0 +1,27 @@
+import { useMemo, useState } from 'react'
+
+// keeps the selection a subset of the polygons on screen. a re-trace mints
+// fresh ids, so a stale selection counts tools that no longer exist. derived
+// rather than pruned in an effect so the count is right on the same render.
+export function usePolygonSelection(
+  polygons: readonly { id: string }[],
+): [Set<string>, (next: Set<string>) => void] {
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  const live = useMemo(() => {
+    const present = new Set(polygons.map(p => p.id))
+    let stale = false
+    for (const id of selected) {
+      if (!present.has(id)) {
+        stale = true
+        break
+      }
+    }
+    // keep the same instance while every id still resolves, so consumers
+    // holding the set in an effect dependency do not re-run needlessly
+    if (!stale) return selected
+    return new Set([...selected].filter(id => present.has(id)))
+  }, [polygons, selected])
+
+  return [live, setSelected]
+}


### PR DESCRIPTION
## Summary

- Selection of traced tools lived in a plain `useState<Set<string>>` on the trace page. Each trace mints fresh uuids for its polygons, so a selection made before a re-trace survived while pointing at polygons that no longer existed. The counter read "3 of 2 selected".
- Not display-only, as the issue suspected: `handleSaveToLibrary` posted the stale ids and the backend filtered them on save, so the button could offer to save 3 tools and save fewer.
- `usePolygonSelection` now owns the set and keeps it a subset of the polygons on screen. Pruning derives during render rather than in an effect, so there is no frame where the counter is wrong. Ids surviving a re-trace stay selected.
- Resetting at the call sites was rejected: three separate paths replace polygons, and a fourth would silently reintroduce the bug. Deriving from `polygons` covers all of them.
- The hook returns `(next: Set<string>) => void` rather than a `Dispatch<SetStateAction<...>>`. The updater form the wider type permits would hand back the raw unpruned state, so the narrower type keeps that trap out of reach.

## Test evidence

`pnpm test` 145 passed / 17 files (145 = 143 baseline + 2 added)
`make lint` exit 0, 0 errors, 9 pre-existing warnings in untouched files
`npx tsc --noEmit` exit 0

Backend pytest not run: the diff touches no backend files.

The 9 hook tests were checked against deliberately broken pruning, not just against the fix. The referential-stability test was vacuous in an earlier revision (it reused one array reference, so the memo never recomputed and the assertion held even against broken logic); it now reassigns a fresh array and fails correctly when the stale-check is removed.

Closes #201