### PR TITLE
Purge generated exports on a configurable retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ By default, Tracefinity uses [IS-Net](https://github.com/xuebinqin/DIS) for loca
 | `MAX_UPLOAD_MB` | `20` | Maximum compressed upload size in megabytes |
 | `MAX_IMAGE_PIXELS` | `64000000` | Maximum decoded pixels accepted before downscaling |
 | `STL_GENERATION_CONCURRENCY` | unlimited | Process-wide maximum STL generation jobs; excess jobs wait up to 5 seconds, then receive 503 |
+| `STL_RETENTION_HOURS` | `24` | Hours generated STL/3MF/zip exports are kept before a background sweep deletes them; a bin page regenerates them on the next visit or export download. `0` keeps exports forever |
 | `TRACEFINITY_ONNX_PROVIDER` | `auto` | Local ONNX provider: `auto`, `cuda`, or `cpu` |
 | `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Gemini model for mask generation (see below) |
 | `TOOL_LABEL_PROVIDER` | `none` | Optional automatic tool naming. Set to `ollama` for local vision naming |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -644,6 +644,13 @@ def _run_generate(
         if not (output_path.exists() and hash_path.exists() and hash_path.read_text() == input_hash):
             return None
         part_paths = sorted(user_path.glob(f"outputs/{entity_id}_part*.stl"))
+        # cache hits rewrite nothing, so refresh mtimes or the retention
+        # sweep could purge artefacts a live page was just handed urls for
+        for artefact in (output_path, hash_path, threemf_path, zip_path, insert_path, *part_paths):
+            try:
+                os.utime(artefact)
+            except FileNotFoundError:
+                pass
         stl_urls = [f"/storage/{user_id}/outputs/{p.name}" for p in part_paths]
         insert_stl_url = (
             f"/storage/{user_id}/outputs/{entity_id}_insert.stl"
@@ -1425,8 +1432,12 @@ async def download_stl(request: Request, session_id: str, user_id: str = Depends
     if not session or not session.stl_path:
         raise HTTPException(status_code=404, detail="stl not found")
 
+    stl_abs = _abs(session.stl_path)
+    if not Path(stl_abs).exists():
+        raise HTTPException(status_code=404, detail="stl expired; regenerate the bin")
+
     return FileResponse(
-        _abs(session.stl_path),
+        stl_abs,
         media_type="application/sla",
         filename=f"tracefinity-{session_id[:8]}.stl",
     )
@@ -1437,6 +1448,10 @@ async def download_zip(request: Request, session_id: str, user_id: str = Depends
     up = _user_path(user_id)
     zip_path = up / "outputs" / f"{session_id}_parts.zip"
     if not zip_path.exists():
+        user_sessions, _, _ = get_stores(user_id)
+        session = user_sessions.get(session_id)
+        if session and session.stl_path:
+            raise HTTPException(status_code=404, detail="zip expired; regenerate the bin")
         raise HTTPException(status_code=404, detail="zip not found")
 
     return FileResponse(
@@ -1455,7 +1470,7 @@ async def download_threemf(request: Request, session_id: str, user_id: str = Dep
 
     threemf_path = Path(_abs(session.stl_path)).with_suffix(".3mf")
     if not threemf_path.exists():
-        raise HTTPException(status_code=404, detail="3mf not found")
+        raise HTTPException(status_code=404, detail="3mf expired; regenerate the bin")
 
     return FileResponse(
         str(threemf_path),
@@ -2190,8 +2205,11 @@ async def download_bin_stl(request: Request, bin_id: str, user_id: str = Depends
     bin_data = user_bins.get(bin_id)
     if not bin_data or not bin_data.stl_path:
         raise HTTPException(status_code=404, detail="stl not found")
+    stl_abs = _abs(bin_data.stl_path)
+    if not Path(stl_abs).exists():
+        raise HTTPException(status_code=404, detail="stl expired; regenerate the bin")
     return FileResponse(
-        _abs(bin_data.stl_path),
+        stl_abs,
         media_type="application/sla",
         filename=f"{_bin_stem(bin_data)}.stl",
     )
@@ -2201,10 +2219,12 @@ async def download_bin_stl(request: Request, bin_id: str, user_id: str = Depends
 async def download_bin_zip(request: Request, bin_id: str, user_id: str = Depends(get_user_id)):
     _, _, user_bins = get_stores(user_id)
     up = _user_path(user_id)
+    bin_data = user_bins.get(bin_id)
     zip_path = up / "outputs" / f"{bin_id}_parts.zip"
     if not zip_path.exists():
+        if bin_data and bin_data.stl_path:
+            raise HTTPException(status_code=404, detail="zip expired; regenerate the bin")
         raise HTTPException(status_code=404, detail="zip not found")
-    bin_data = user_bins.get(bin_id)
     fname = f"{_bin_stem(bin_data)}-parts.zip" if bin_data else f"{bin_id[:8]}-parts.zip"
     return FileResponse(
         str(zip_path),
@@ -2221,7 +2241,7 @@ async def download_bin_threemf(request: Request, bin_id: str, user_id: str = Dep
         raise HTTPException(status_code=404, detail="3mf not found")
     threemf_path = Path(_abs(bin_data.stl_path)).with_suffix(".3mf")
     if not threemf_path.exists():
-        raise HTTPException(status_code=404, detail="3mf not found")
+        raise HTTPException(status_code=404, detail="3mf expired; regenerate the bin")
     return FileResponse(
         str(threemf_path),
         media_type="application/vnd.ms-package.3dmanufacturing-3dmodel+xml",
@@ -2233,10 +2253,12 @@ async def download_bin_threemf(request: Request, bin_id: str, user_id: str = Dep
 async def download_bin_insert(request: Request, bin_id: str, user_id: str = Depends(get_user_id)):
     _, _, user_bins = get_stores(user_id)
     up = _user_path(user_id)
+    bin_data = user_bins.get(bin_id)
     insert_path = up / "outputs" / f"{bin_id}_insert.stl"
     if not insert_path.exists():
+        if bin_data and bin_data.stl_path:
+            raise HTTPException(status_code=404, detail="insert stl expired; regenerate the bin")
         raise HTTPException(status_code=404, detail="insert stl not found")
-    bin_data = user_bins.get(bin_id)
     fname = f"{_bin_stem(bin_data)}-insert.stl" if bin_data else f"{bin_id[:8]}-insert.stl"
     return FileResponse(
         str(insert_path),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
     max_upload_mb: int = 20
     max_image_pixels: int = Field(default=64_000_000, gt=0)
     stl_generation_concurrency: Optional[int] = Field(default=None, gt=0)
+    # hours generated export artefacts are kept; 0 keeps them forever
+    stl_retention_hours: float = Field(default=24, ge=0)
     log_level: str = "INFO"
     proxy_secret: Optional[str] = None
     cors_origins: list[str] = ["http://localhost:3000", "http://localhost:4001"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from posixpath import normpath
 
@@ -11,6 +12,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from app.config import settings
+from app.services.output_retention import retention_loop
 from app.services.store_errors import StoreClosedError
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
@@ -64,6 +66,15 @@ def _configure_uvicorn_logging():
             h.setFormatter(fmt)
 
 
+@app.on_event("startup")
+async def _start_output_retention():
+    if settings.stl_retention_hours > 0:
+        # reference kept on app.state so the task is not garbage collected
+        app.state.output_retention_task = asyncio.create_task(
+            retention_loop(settings.storage_path, settings.stl_retention_hours)
+        )
+
+
 class ProxySecretMiddleware(BaseHTTPMiddleware):
     """only trust user-scoped headers from an authenticated proxy."""
 
@@ -105,6 +116,8 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    # frontend blob downloads read the server-set filename cross-origin in dev
+    expose_headers=["Content-Disposition"],
 )
 
 app.mount("/storage", StaticFiles(directory=str(settings.storage_path)), name="storage")

--- a/backend/app/services/output_retention.py
+++ b/backend/app/services/output_retention.py
@@ -1,0 +1,60 @@
+"""retention sweep for generated export artefacts.
+
+STLs, 3MFs, part zips, and generation hash markers are regenerable from
+stored polygons and bin config, so they are purged once older than the
+configured retention. scope is deliberately tight: only files directly
+inside each user's outputs/ dir with an export suffix. photos, traces,
+tool/bin/session stores, and anything nested are never touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SWEEP_INTERVAL_SECONDS = 15 * 60
+
+# every file _run_generate writes ends in one of these
+_ARTEFACT_SUFFIXES = {".stl", ".3mf", ".zip", ".hash"}
+
+
+def sweep_expired_outputs(storage_path: Path, retention_hours: float, now: float | None = None) -> int:
+    """delete export artefacts older than retention_hours; returns count removed.
+
+    retention_hours <= 0 disables the sweep entirely (keep forever).
+    """
+    if retention_hours <= 0:
+        return 0
+    cutoff = (now if now is not None else time.time()) - retention_hours * 3600
+    removed = 0
+    for outputs_dir in sorted(storage_path.glob("*/outputs")):
+        if not outputs_dir.is_dir():
+            continue
+        for entry in outputs_dir.iterdir():
+            if entry.suffix not in _ARTEFACT_SUFFIXES:
+                continue
+            try:
+                if not entry.is_file() or entry.stat().st_mtime >= cutoff:
+                    continue
+                entry.unlink()
+            except FileNotFoundError:
+                # generation or deletion raced the sweep; nothing left to do
+                continue
+            removed += 1
+    return removed
+
+
+async def retention_loop(storage_path: Path, retention_hours: float) -> None:
+    """periodic sweep; first pass runs immediately to catch crash leftovers."""
+    while True:
+        try:
+            removed = await asyncio.to_thread(sweep_expired_outputs, storage_path, retention_hours)
+            if removed:
+                logger.info("retention sweep removed %d expired export file(s)", removed)
+        except Exception:
+            logger.exception("retention sweep failed")
+        await asyncio.sleep(SWEEP_INTERVAL_SECONDS)

--- a/backend/tests/test_output_retention.py
+++ b/backend/tests/test_output_retention.py
@@ -1,0 +1,280 @@
+"""retention sweep for generated export artefacts (issue #176)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+import app.api.routes as routes
+import app.services.output_retention as output_retention
+from app.config import Settings, ensure_user_dirs, settings
+from app.main import app
+from app.models.schemas import BinModel, GenerateRequest, Session
+from app.services.output_retention import sweep_expired_outputs
+
+HOUR = 3600.0
+
+FAMILY = [
+    "e1.stl",
+    "e1.hash",
+    "e1.3mf",
+    "e1_parts.zip",
+    "e1_insert.stl",
+    "e1_part1.stl",
+    "e1_part2.stl",
+]
+
+
+class _OpenStore:
+    def ensure_open(self):
+        pass
+
+
+def _write_aged(directory: Path, name: str, age_hours: float, now: float, content: bytes = b"x") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_bytes(content)
+    stamp = now - age_hours * HOUR
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+# --- settings ---
+
+
+def test_stl_retention_defaults_to_24_hours(monkeypatch):
+    monkeypatch.delenv("STL_RETENTION_HOURS", raising=False)
+    assert Settings(_env_file=None).stl_retention_hours == 24
+
+
+def test_stl_retention_zero_disables(monkeypatch):
+    monkeypatch.setenv("STL_RETENTION_HOURS", "0")
+    assert Settings(_env_file=None).stl_retention_hours == 0
+
+
+def test_stl_retention_rejects_negative_values(monkeypatch):
+    monkeypatch.setenv("STL_RETENTION_HOURS", "-1")
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None)
+
+
+# --- sweep ---
+
+
+def test_sweep_removes_expired_artefacts_for_every_user(tmp_path):
+    now = time.time()
+    expired = [
+        _write_aged(tmp_path / "default" / "outputs", name, 25, now) for name in FAMILY
+    ] + [_write_aged(tmp_path / "user-2" / "outputs", "b2.stl", 30, now)]
+
+    removed = sweep_expired_outputs(tmp_path, 24, now=now)
+
+    assert removed == len(expired)
+    assert all(not p.exists() for p in expired)
+
+
+def test_sweep_keeps_artefacts_younger_than_retention(tmp_path):
+    now = time.time()
+    fresh = [
+        _write_aged(tmp_path / "default" / "outputs", name, 23, now) for name in FAMILY
+    ]
+
+    removed = sweep_expired_outputs(tmp_path, 24, now=now)
+
+    assert removed == 0
+    assert all(p.exists() for p in fresh)
+
+
+def test_sweep_zero_retention_keeps_everything(tmp_path):
+    now = time.time()
+    old = _write_aged(tmp_path / "default" / "outputs", "e1.stl", 24 * 365, now)
+
+    removed = sweep_expired_outputs(tmp_path, 0, now=now)
+
+    assert removed == 0
+    assert old.exists()
+
+
+def test_sweep_only_touches_export_artefacts_in_outputs(tmp_path):
+    now = time.time()
+    user = tmp_path / "default"
+    untouchable = [
+        # export-like suffixes outside outputs/ stay
+        _write_aged(user / "uploads", "photo.stl", 48, now),
+        # decoy directly at the storage root stays
+        _write_aged(tmp_path, "stray.stl", 48, now),
+        _write_aged(user / "processed", "corrected.zip", 48, now),
+        # non-artefact files inside outputs/ stay
+        _write_aged(user / "outputs", "notes.txt", 48, now),
+        _write_aged(user / "outputs", "sessions.json", 48, now),
+        # no recursion below outputs/
+        _write_aged(user / "outputs" / "nested", "old.stl", 48, now),
+        # user photos, tools, bins, session stores stay
+        _write_aged(user / "uploads", "original.jpg", 48, now),
+        _write_aged(user / "tools", "tools.json", 48, now),
+        _write_aged(user / "bins", "bins.json", 48, now),
+    ]
+    dir_named_like_artefact = user / "outputs" / "weird.stl.d"
+    dir_named_like_artefact.mkdir(parents=True)
+    expired = _write_aged(user / "outputs", "old.stl", 48, now)
+
+    removed = sweep_expired_outputs(tmp_path, 24, now=now)
+
+    assert removed == 1
+    assert not expired.exists()
+    assert all(p.exists() for p in untouchable)
+    assert dir_named_like_artefact.exists()
+
+
+def test_sweep_tolerates_files_vanishing_mid_sweep(tmp_path, monkeypatch):
+    now = time.time()
+    vanishing = _write_aged(tmp_path / "default" / "outputs", "gone.stl", 48, now)
+    survivor_target = _write_aged(tmp_path / "default" / "outputs", "old.stl", 48, now)
+
+    real_unlink = Path.unlink
+
+    def flaky_unlink(self, *args, **kwargs):
+        if self.name == "gone.stl":
+            real_unlink(self)
+            raise FileNotFoundError(str(self))
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+    removed = sweep_expired_outputs(tmp_path, 24, now=now)
+
+    assert removed == 1
+    assert not vanishing.exists()
+    assert not survivor_target.exists()
+
+
+def test_retention_loop_survives_sweep_exceptions(monkeypatch, caplog):
+    calls = []
+
+    def flaky_sweep(storage_path, retention_hours):
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("sweep blew up")
+        return 0
+
+    monkeypatch.setattr(output_retention, "sweep_expired_outputs", flaky_sweep)
+    monkeypatch.setattr(output_retention, "SWEEP_INTERVAL_SECONDS", 0)
+
+    async def run_until_second_sweep():
+        task = asyncio.create_task(output_retention.retention_loop(Path("/nowhere"), 1))
+        try:
+            for _ in range(500):
+                if len(calls) >= 2:
+                    break
+                await asyncio.sleep(0.005)
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    asyncio.run(run_until_second_sweep())
+
+    assert len(calls) >= 2, "loop stopped after a failing sweep"
+    assert any("retention sweep failed" in r.message for r in caplog.records)
+
+
+# --- cache hits refresh mtimes so live pages keep their files ---
+
+
+def test_cached_generate_refreshes_artefact_mtimes(tmp_path, monkeypatch):
+    monkeypatch.setattr(routes, "_stl_generation_semaphore", None)
+    now = time.time()
+    paths = [
+        _write_aged(tmp_path / "outputs", name, 25, now, content=b"h1" if name.endswith(".hash") else b"x")
+        for name in FAMILY
+    ]
+
+    response = routes._run_generate(
+        [], GenerateRequest(), "e1", tmp_path, "h1", "default", _OpenStore()
+    )
+
+    assert response.stl_url == "/storage/default/outputs/e1.stl"
+    for p in paths:
+        assert p.stat().st_mtime >= now - 60, f"{p.name} mtime not refreshed"
+
+
+# --- purged files fail clearly, not with a 500 ---
+
+
+def _client(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "storage_path", tmp_path)
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    routes._store_cache.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def test_session_stl_download_404s_when_file_purged(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    user_sessions, _, _ = routes.get_stores("default")
+    user_sessions.set("s1", Session(id="s1", stl_path="default/outputs/s1.stl"))
+
+    resp = client.get("/api/files/s1/bin.stl")
+
+    assert resp.status_code == 404
+    assert "regenerate" in resp.json()["detail"]
+
+
+def test_bin_stl_download_404s_when_file_purged(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    _, _, user_bins = routes.get_stores("default")
+    user_bins.set("b1", BinModel(id="b1", stl_path="default/outputs/b1.stl"))
+
+    resp = client.get("/api/files/bins/b1/bin.stl")
+
+    assert resp.status_code == 404
+    assert "regenerate" in resp.json()["detail"]
+
+
+def test_session_export_404s_distinguish_expiry_from_never_generated(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    user_sessions, _, _ = routes.get_stores("default")
+    user_sessions.set("s1", Session(id="s1", stl_path="default/outputs/s1.stl"))
+
+    for path in ("/api/files/s1/bin.3mf", "/api/files/s1/bin_parts.zip"):
+        resp = client.get(path)
+        assert resp.status_code == 404
+        assert "regenerate" in resp.json()["detail"], path
+
+    for path in ("/api/files/unknown/bin.3mf", "/api/files/unknown/bin_parts.zip"):
+        resp = client.get(path)
+        assert resp.status_code == 404
+        assert "regenerate" not in resp.json()["detail"], path
+
+
+def test_bin_export_404s_distinguish_expiry_from_never_generated(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    _, _, user_bins = routes.get_stores("default")
+    user_bins.set("b1", BinModel(id="b1", stl_path="default/outputs/b1.stl"))
+
+    expired = (
+        "/api/files/bins/b1/bin.3mf",
+        "/api/files/bins/b1/bin_parts.zip",
+        "/api/files/bins/b1/bin_insert.stl",
+    )
+    for path in expired:
+        resp = client.get(path)
+        assert resp.status_code == 404
+        assert "regenerate" in resp.json()["detail"], path
+
+    never_generated = (
+        "/api/files/bins/unknown/bin.3mf",
+        "/api/files/bins/unknown/bin_parts.zip",
+        "/api/files/bins/unknown/bin_insert.stl",
+    )
+    for path in never_generated:
+        resp = client.get(path)
+        assert resp.status_code == 404
+        assert "regenerate" not in resp.json()["detail"], path

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,3 +76,7 @@ Response fields:
 - `GET /api/files/bins/{bin_id}/bin.stl` - bin STL
 - `GET /api/files/bins/{bin_id}/bin.3mf` - bin 3MF
 - `GET /api/files/bins/{bin_id}/bin_parts.zip` - bin split parts
+
+Exports are subject to the retention sweep (`STL_RETENTION_HOURS`, see
+[stl-generation.md](stl-generation.md)); a purged file returns `404` until the
+bin is regenerated.

--- a/docs/stl-generation.md
+++ b/docs/stl-generation.md
@@ -17,6 +17,26 @@ The limit is per process, not shared across processes or replicas. Tracefinity
 currently runs as a single backend process, so a value of `1` serializes STL
 generation for the standard deployment.
 
+## Export retention
+
+Generated exports are regenerable from the stored polygons and bin config, so
+they are not kept indefinitely. A background sweep runs every 15 minutes and
+deletes export files older than `STL_RETENTION_HOURS` (default 24). Set it to
+`0` to keep exports forever.
+
+The sweep only removes files directly inside each user's `outputs/` directory
+with an export suffix: `.stl`, `.3mf`, `.zip`, and the `.hash` cache marker.
+Photos, traces, tools, bins, projects, and session data are never touched.
+
+Opening a bin page re-requests generation, which either refreshes the existing
+files (cache hit, which also resets their retention clock) or rebuilds them
+from saved state. The bin page's export buttons also recover on demand: a
+download that finds its file purged regenerates the bin and retries. Trace
+pages never request generation, so a purged session-flow export stays gone
+until generation is requested again. A purged export endpoint returns `404`
+with `<artefact> expired; regenerate the bin` when a prior generation is on
+record, and `<artefact> not found` otherwise.
+
 ## Z-Axis Reference Heights
 
 - **Base top**: 4.75mm (three tapered layers: 2.15 + 1.8 + 0.8). Infill starts here.

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -8,6 +8,7 @@ import { BinPreview3D } from '@/components/BinPreview3D'
 import { ToolBrowser } from '@/components/ToolBrowser'
 import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from '@/lib/api'
 import { buildBinConfig, createPartialBinsValues, getDefaultBinConfig, resetDefaultBinConfig, saveDefaultBinConfig } from '@/lib/binDefaults'
+import { downloadExport } from '@/lib/download'
 import type { BinConfig, BinData, PlacedTool, TextLabel } from '@/types'
 import { Download, Loader2, Package, ChevronDown, Check, TriangleAlert } from 'lucide-react'
 import { Breadcrumb } from '@/components/Breadcrumb'
@@ -356,20 +357,34 @@ export default function BinPage() {
     setPlacedTools(prev => [...prev, placed])
   }, [config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base])
 
+  // the retention sweep purges exports, so a stale tab's file may be gone;
+  // downloadExport regenerates from saved state and retries before failing
+  const handleExport = useCallback(async (url: string) => {
+    try {
+      await downloadExport(url, async () => {
+        // clear the dedupe key or an unchanged layout skips regeneration
+        lastGenerateRef.current = ''
+        await doGenerate()
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'export download failed')
+    }
+  }, [doGenerate])
+
   function handleDownload() {
-    window.open(getBinStlUrl(binId), '_blank')
+    handleExport(getBinStlUrl(binId))
   }
 
   function handleDownloadZip() {
-    window.open(getBinZipUrl(binId), '_blank')
+    handleExport(getBinZipUrl(binId))
   }
 
   function handleDownloadThreemf() {
-    window.open(getBinThreemfUrl(binId), '_blank')
+    handleExport(getBinThreemfUrl(binId))
   }
 
   function handleDownloadInsert() {
-    window.open(getBinInsertUrl(binId), '_blank')
+    handleExport(getBinInsertUrl(binId))
   }
 
   function showDefaultsStatus(message: string) {

--- a/frontend/src/lib/download.test.ts
+++ b/frontend/src/lib/download.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { downloadExport } from './download'
+
+function mockResponse(status: number, headers: Record<string, string> = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    blob: async () => new Blob(['solid bin']),
+  } as unknown as Response
+}
+
+describe('downloadExport', () => {
+  let clicks: { href: string; download: string }[]
+
+  beforeEach(() => {
+    clicks = []
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      clicks.push({ href: this.href, download: this.download })
+    })
+    URL.createObjectURL = vi.fn(() => 'blob:mock')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('downloads via an anchor click using the server filename', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      mockResponse(200, { 'content-disposition': 'attachment; filename="Bin_2u3u6u_20mm-tracefinity.stl"' })
+    ))
+    const regenerate = vi.fn()
+
+    await downloadExport('http://api/api/files/bins/b1/bin.stl', regenerate)
+
+    expect(regenerate).not.toHaveBeenCalled()
+    expect(clicks).toEqual([{ href: 'blob:mock', download: 'Bin_2u3u6u_20mm-tracefinity.stl' }])
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+  })
+
+  it('regenerates and retries once when the export has been purged', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResponse(404))
+      .mockResolvedValueOnce(mockResponse(200, { 'content-disposition': 'attachment; filename="bin.stl"' }))
+    vi.stubGlobal('fetch', fetchMock)
+    const regenerate = vi.fn(async () => {})
+
+    await downloadExport('http://api/api/files/bins/b1/bin.stl', regenerate)
+
+    expect(regenerate).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(clicks).toEqual([{ href: 'blob:mock', download: 'bin.stl' }])
+  })
+
+  it('throws when the export is still missing after regenerating', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => mockResponse(404)))
+    const regenerate = vi.fn(async () => {})
+
+    await expect(downloadExport('http://api/api/files/bins/b1/bin.stl', regenerate))
+      .rejects.toThrow('export download failed (404)')
+
+    expect(regenerate).toHaveBeenCalledTimes(1)
+    expect(clicks).toEqual([])
+  })
+
+  it('throws on non-404 errors without regenerating', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => mockResponse(500)))
+    const regenerate = vi.fn()
+
+    await expect(downloadExport('http://api/api/files/bins/b1/bin.stl', regenerate))
+      .rejects.toThrow('export download failed (500)')
+
+    expect(regenerate).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the url basename when no disposition header is readable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => mockResponse(200)))
+
+    await downloadExport('http://api/api/files/bins/b1/bin_parts.zip?v=3', vi.fn())
+
+    expect(clicks).toEqual([{ href: 'blob:mock', download: 'bin_parts.zip' }])
+  })
+
+  it('decodes rfc 5987 encoded filenames', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      mockResponse(200, { 'content-disposition': "attachment; filename*=utf-8''caf%C3%A9.stl" })
+    ))
+
+    await downloadExport('http://api/api/files/bins/b1/bin.stl', vi.fn())
+
+    expect(clicks).toEqual([{ href: 'blob:mock', download: 'café.stl' }])
+  })
+})

--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -1,0 +1,40 @@
+// export artefacts are purged after the retention window (docs/stl-generation.md);
+// a 404 means the file expired, so regenerate and retry once instead of
+// surfacing the raw json error to the user
+
+function filenameFromDisposition(header: string | null): string | null {
+  if (!header) return null
+  const utf8 = /filename\*=utf-8''([^;]+)/i.exec(header)
+  if (utf8) {
+    try {
+      return decodeURIComponent(utf8[1].trim())
+    } catch {
+      return null
+    }
+  }
+  const plain = /filename="?([^";]+)"?/i.exec(header)
+  return plain ? plain[1].trim() : null
+}
+
+function fallbackFilename(url: string): string {
+  const path = url.split(/[?#]/)[0]
+  return path.split('/').pop() || 'download'
+}
+
+export async function downloadExport(url: string, regenerate: () => Promise<void>): Promise<void> {
+  let response = await fetch(url)
+  if (response.status === 404) {
+    await regenerate()
+    response = await fetch(url)
+  }
+  if (!response.ok) {
+    throw new Error(`export download failed (${response.status})`)
+  }
+  const blob = await response.blob()
+  const objectUrl = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = objectUrl
+  link.download = filenameFromDisposition(response.headers.get('content-disposition')) ?? fallbackFilename(url)
+  link.click()
+  URL.revokeObjectURL(objectUrl)
+}


### PR DESCRIPTION
## Summary

- Generated exports (STL, 3MF, zip, hash sidecars) are regenerable from stored polygons and config, so there is no reason to keep them indefinitely. A background sweep now purges files in `{storage}/*/outputs/` older than `STL_RETENTION_HOURS` (default 24; `0` keeps everything for self-hosters who want that).
- Sweep-only rather than delete-on-download: the 3D preview streams the same file the download buttons use through an unhookable StaticFiles mount, so deleting on first fetch would break the preview. Cache hits touch mtimes, so a bin in daily use never expires.
- Deletion scope is deliberately narrow: fixed-depth glob, suffix allowlist, no recursion. Photos, polygons, projects and stores are structurally out of reach.
- The stale-tab case (open past retention, no edits) is handled end to end: expired downloads now 404 with a regenerate hint instead of crashing mid-response, and the bin page's export buttons fetch, regenerate on 404 and retry once, delivering via blob with the server filename. Sibling 3MF/zip/insert endpoints distinguish "expired" from "never generated".
- Docs updated (README env table, docs/stl-generation.md, docs/api.md), including the honest caveat that only bin pages self-heal; session-flow exports stay purged until generation is re-requested.

## Test evidence

`backend/venv/bin/python -m pytest` 370 passed (356 baseline + 14 new)
`pnpm test` 151 passed / 18 files (145 baseline + 6 new)
`make lint` exit 0, 0 errors, 9 pre-existing warnings in untouched files
`npx tsc --noEmit` clean

Retention loop is tested for exception survival (a raising sweep is logged and the loop continues). Scope tests include decoy files at storage root, wrong suffixes, nested dirs and sibling stores, all asserted to survive. The 404-then-regenerate download path is unit-tested including the no-regenerate-on-500 and throw-on-double-404 branches.

Closes #176