### PR TITLE
Add administrator API tokens

### DIFF
--- a/backend/app/api/admin_routes.py
+++ b/backend/app/api/admin_routes.py
@@ -4,12 +4,21 @@ create supports importing accounts from a prior system: an externally hashed
 credential (bcrypt or native scrypt), a TOTP secret and backup code hashes.
 imports validate everything first, then land in one atomic store write; a
 repeated import of the same id and email is a no-op, never an overwrite.
+
+two dependencies split this surface. get_admin_principal accepts either a
+login session or an admin token, and covers the provisioning routes.
+get_admin_session_principal accepts a session only, and covers clearing a
+second factor and managing the tokens themselves: neither belongs to a
+credential that authenticates without a second factor.
+
+every mutation logs principal.actor, which names the account and, when a
+token was used, the token.
 """
 from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from starlette.responses import Response
@@ -23,13 +32,22 @@ from app.api.auth_common import (
     validate_backup_code_hashes,
     validate_new_password,
 )
-from app.auth import get_admin_account, valid_user_id
+from app.auth import (
+    AdminPrincipal,
+    get_admin_principal,
+    get_admin_session_principal,
+    valid_user_id,
+)
 from app.config import ensure_user_dirs, settings
 from app.models.accounts import Account
 from app.models.auth_schemas import (
     AccountResponse,
     AdminCreateUserRequest,
     AdminResetPasswordRequest,
+    AdminTokenIssuedResponse,
+    AdminTokenListResponse,
+    AdminTokenRequest,
+    AdminTokenResponse,
     AdminUserListResponse,
 )
 from app.services import namespace_tombstones, secret_box
@@ -45,13 +63,15 @@ router = APIRouter()
 
 
 @router.get("/admin/users", response_model=AdminUserListResponse)
-def list_users(admin: Account = Depends(get_admin_account)):
+def list_users(principal: AdminPrincipal = Depends(get_admin_principal)):
     accounts = sorted(get_account_store().all(), key=lambda a: a.created_at)
     return AdminUserListResponse(users=[account_response(a) for a in accounts])
 
 
 @router.post("/admin/users", response_model=AccountResponse)
-def create_user(req: AdminCreateUserRequest, admin: Account = Depends(get_admin_account)):
+def create_user(
+    req: AdminCreateUserRequest, principal: AdminPrincipal = Depends(get_admin_principal)
+):
     # validate everything before touching the store: a partial failure must
     # leave nothing behind
     email = normalise_email(req.email)
@@ -116,25 +136,28 @@ def create_user(req: AdminCreateUserRequest, admin: Account = Depends(get_admin_
     except DuplicateAccountError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     ensure_user_dirs(settings.storage_path / account.storage_namespace)
-    logger.info("admin %s created account %s", admin.id, account.id)
+    logger.info("admin %s created account %s", principal.actor, account.id)
     return account_response(account)
 
 
 @router.post("/admin/users/{account_id}/disable", response_model=AccountResponse)
-def disable_user(account_id: str, admin: Account = Depends(get_admin_account)):
-    if account_id == admin.id:
+def disable_user(account_id: str, principal: AdminPrincipal = Depends(get_admin_principal)):
+    if account_id == principal.account.id:
         raise HTTPException(status_code=400, detail="cannot disable your own account")
     def disable(live: Account):
         live.disabled = True
 
     account = apply_to_account(account_id, disable)
-    # locked out now, not at token expiry
+    # locked out now, not at token expiry. the account's admin tokens survive
+    # the disable and go inert with it, because every one of them is checked
+    # against the live account on use; enabling the account restores them
     get_auth_token_store().revoke_for_account(account_id)
+    logger.info("admin %s disabled account %s", principal.actor, account_id)
     return account_response(account)
 
 
 @router.post("/admin/users/{account_id}/enable", response_model=AccountResponse)
-def enable_user(account_id: str, admin: Account = Depends(get_admin_account)):
+def enable_user(account_id: str, principal: AdminPrincipal = Depends(get_admin_principal)):
     def enable(live: Account):
         live.disabled = False
 
@@ -142,6 +165,7 @@ def enable_user(account_id: str, admin: Account = Depends(get_admin_account)):
     # a re-enabled account must not stay locked out by the failures that
     # piled up while it was disabled
     login_limiter.reset(account.email)
+    logger.info("admin %s enabled account %s", principal.actor, account_id)
     return account_response(account)
 
 
@@ -149,7 +173,7 @@ def enable_user(account_id: str, admin: Account = Depends(get_admin_account)):
 def reset_password(
     account_id: str,
     req: AdminResetPasswordRequest,
-    admin: Account = Depends(get_admin_account),
+    principal: AdminPrincipal = Depends(get_admin_principal),
 ):
     validate_new_password(req.password)
     new_hash = hash_password(req.password)
@@ -161,12 +185,20 @@ def reset_password(
     get_auth_token_store().revoke_for_account(account_id)
     # recovery is pointless if the lockout that prompted it survives
     login_limiter.reset(account.email)
+    logger.info("admin %s reset the password for account %s", principal.actor, account_id)
     return Response(status_code=204)
 
 
 @router.post("/admin/users/{account_id}/clear-2fa")
-def clear_two_factor(account_id: str, admin: Account = Depends(get_admin_account)):
-    """recovery path for a lost authenticator; no email infrastructure needed"""
+def clear_two_factor(
+    account_id: str, principal: AdminPrincipal = Depends(get_admin_session_principal)
+):
+    """recovery path for a lost authenticator; no email infrastructure needed.
+
+    session only. an admin token authenticates with no second factor, so
+    letting one strip second factors would make every account it can reset a
+    password on takeable by whoever holds the token.
+    """
     def clear(live: Account):
         live.totp_enabled = False
         live.totp_secret = None
@@ -174,4 +206,58 @@ def clear_two_factor(account_id: str, admin: Account = Depends(get_admin_account
         live.backup_code_hashes = []
 
     apply_to_account(account_id, clear)
+    logger.info("admin %s cleared 2FA on account %s", principal.actor, account_id)
+    return Response(status_code=204)
+
+
+def _token_response(record) -> AdminTokenResponse:
+    return AdminTokenResponse(
+        id=record.token_id,
+        account_id=record.account_id,
+        label=record.label,
+        created_at=record.created_at,
+        expires_at=record.expires_at,
+        last_used_at=record.last_used_at,
+    )
+
+
+@router.post("/admin/tokens", response_model=AdminTokenIssuedResponse)
+def issue_admin_token(
+    req: AdminTokenRequest | None = None,
+    principal: AdminPrincipal = Depends(get_admin_session_principal),
+):
+    """mint a non-interactive administrator credential.
+
+    session only, so a token cannot mint a successor: revoking the tokens an
+    administrator issued is then enough to contain a leak, with no chain to
+    chase. the raw value is in this response and nowhere else, ever.
+    """
+    # a bodyless POST is the common case from a shell, so it is not an error
+    req = req or AdminTokenRequest()
+    expires_at = None
+    if req.expires_in_days is not None:
+        expires_at = datetime.now(timezone.utc) + timedelta(days=req.expires_in_days)
+    record, raw = get_auth_token_store().issue_admin_token(
+        principal.account.id, label=req.label.strip(), expires_at=expires_at
+    )
+    logger.info("admin %s issued admin token %s", principal.actor, record.token_id)
+    return AdminTokenIssuedResponse(**_token_response(record).model_dump(), token=raw)
+
+
+@router.get("/admin/tokens", response_model=AdminTokenListResponse)
+def list_admin_tokens(principal: AdminPrincipal = Depends(get_admin_session_principal)):
+    """every admin token on the instance, not only the caller's: containing a
+    leak means seeing and revoking whatever any administrator issued"""
+    return AdminTokenListResponse(
+        tokens=[_token_response(r) for r in get_auth_token_store().list_admin_tokens()]
+    )
+
+
+@router.delete("/admin/tokens/{token_id}")
+def revoke_admin_token(
+    token_id: str, principal: AdminPrincipal = Depends(get_admin_session_principal)
+):
+    if not get_auth_token_store().revoke_admin_token(token_id):
+        raise HTTPException(status_code=404, detail="token not found")
+    logger.info("admin %s revoked admin token %s", principal.actor, token_id)
     return Response(status_code=204)

--- a/backend/app/api/admin_routes.py
+++ b/backend/app/api/admin_routes.py
@@ -9,7 +9,15 @@ two dependencies split this surface. get_admin_principal accepts either a
 login session or an admin token, and covers the provisioning routes.
 get_admin_session_principal accepts a session only, and covers clearing a
 second factor and managing the tokens themselves: neither belongs to a
-credential that authenticates without a second factor.
+credential that authenticates without a second factor. the router declares
+the first as its default, so a route added without an explicit dependency is
+authenticated rather than anonymous.
+
+across the routes a token does reach, one further rule holds: a token neither
+creates an administrator nor writes to an account that is one. a token
+authenticates with no password step and no second factor, so an administrator
+it could mint or seize is an interactive login it could take, and every
+containment decision here would fall with it.
 
 every mutation logs principal.actor, which names the account and, when a
 token was used, the token.
@@ -59,7 +67,27 @@ from app.services.password_hashing import hash_password, is_supported_hash
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+# denied by default: an undeclared route inherits an administrator check
+# rather than being open. session-only routes narrow it further, and both
+# must pass
+router = APIRouter(dependencies=[Depends(get_admin_principal)])
+
+
+def _refuse_token_write_to_admin(principal: AdminPrincipal, live: Account) -> None:
+    """stop an admin token writing to an account that holds full authority.
+
+    a token holder who can reset an administrator's password logs in as them
+    interactively, and one who can suspend administrators locks out the humans
+    who could revoke the token. checked against the live record inside the
+    store lock, so it cannot race a change to the target's admin bit.
+    """
+    if principal.token_id is None or not live.is_admin:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail="an admin token cannot modify an administrator account; "
+        "use an administrator session",
+    )
 
 
 @router.get("/admin/users", response_model=AdminUserListResponse)
@@ -72,6 +100,14 @@ def list_users(principal: AdminPrincipal = Depends(get_admin_principal)):
 def create_user(
     req: AdminCreateUserRequest, principal: AdminPrincipal = Depends(get_admin_principal)
 ):
+    if req.is_admin and principal.token_id is not None:
+        # refused rather than downgraded: a provisioning script that asked for
+        # an administrator must not be told it got one
+        raise HTTPException(
+            status_code=403,
+            detail="an admin token cannot create an administrator; "
+            "use an administrator session",
+        )
     # validate everything before touching the store: a partial failure must
     # leave nothing behind
     email = normalise_email(req.email)
@@ -145,6 +181,7 @@ def disable_user(account_id: str, principal: AdminPrincipal = Depends(get_admin_
     if account_id == principal.account.id:
         raise HTTPException(status_code=400, detail="cannot disable your own account")
     def disable(live: Account):
+        _refuse_token_write_to_admin(principal, live)
         live.disabled = True
 
     account = apply_to_account(account_id, disable)
@@ -159,6 +196,7 @@ def disable_user(account_id: str, principal: AdminPrincipal = Depends(get_admin_
 @router.post("/admin/users/{account_id}/enable", response_model=AccountResponse)
 def enable_user(account_id: str, principal: AdminPrincipal = Depends(get_admin_principal)):
     def enable(live: Account):
+        _refuse_token_write_to_admin(principal, live)
         live.disabled = False
 
     account = apply_to_account(account_id, enable)
@@ -179,6 +217,7 @@ def reset_password(
     new_hash = hash_password(req.password)
 
     def set_hash(live: Account):
+        _refuse_token_write_to_admin(principal, live)
         live.password_hash = new_hash
 
     account = apply_to_account(account_id, set_hash)
@@ -228,9 +267,11 @@ def issue_admin_token(
 ):
     """mint a non-interactive administrator credential.
 
-    session only, so a token cannot mint a successor: revoking the tokens an
-    administrator issued is then enough to contain a leak, with no chain to
-    chase. the raw value is in this response and nowhere else, ever.
+    session only, so a token cannot mint a successor here. that alone is not
+    enough: a token able to create an administrator would mint one and log in
+    as it to reach this route, which is why create refuses that. together they
+    mean revoking the tokens an administrator issued contains a leak, with no
+    chain to chase. the raw value is in this response and nowhere else, ever.
     """
     # a bodyless POST is the common case from a shell, so it is not an error
     req = req or AdminTokenRequest()

--- a/backend/app/api/auth_common.py
+++ b/backend/app/api/auth_common.py
@@ -18,7 +18,9 @@ from app.services.auth_token_store import TOKEN_LIFETIME
 from app.services.password_hashing import is_supported_hash
 
 MIN_PASSWORD_LENGTH = 8
-_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+$")
+# \A and \Z for the same reason as _USER_ID_RE: $ tolerates a trailing
+# newline. normalise_email strips first, so this holds the line regardless
+_EMAIL_RE = re.compile(r"\A[^@\s]+@[^@\s]+\Z")
 # below the 128 bits RFC 4226 requires of a generator: an import comes from
 # whatever the prior system issued, and refusing it strands the account
 _MIN_TOTP_SECRET_BYTES = 10

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -31,7 +31,9 @@ def _delete_native_account(request: Request) -> bool:
         get_account_store().delete(account.id)
     except LastAdminError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    get_auth_token_store().revoke_for_account(account.id)
+    # everything, admin tokens included: the account is gone, so nothing
+    # issued under it may outlive it
+    get_auth_token_store().revoke_all_for_account(account.id)
     logger.info("deleted account %s", account.id)
     return True
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -13,8 +13,11 @@ from app.models.accounts import Account
 
 AUTH_COOKIE_NAME = "tracefinity_auth"
 
-# allow cuid (25 alphanumeric) or uuid (36 hex+hyphens); block path traversal
-_USER_ID_RE = re.compile(r"^[a-z0-9]{25}$|^[a-f0-9-]{36}$")
+# allow cuid (25 alphanumeric) or uuid (36 hex+hyphens); block path traversal.
+# \A and \Z, not ^ and $: $ also matches before a trailing newline, so an
+# id ending in one would pass and become a directory name containing it.
+# anchoring the group rather than each branch keeps the two in step
+_USER_ID_RE = re.compile(r"\A(?:[a-z0-9]{25}|[a-f0-9-]{36})\Z")
 
 
 def valid_user_id(raw: str) -> bool:

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hmac
 import re
+from dataclasses import dataclass
 from typing import Optional
 
 from fastapi import HTTPException
@@ -73,6 +74,77 @@ async def get_admin_account(request: Request) -> Account:
     if not account.is_admin:
         raise HTTPException(status_code=403, detail="administrator access required")
     return account
+
+
+@dataclass(frozen=True)
+class AdminPrincipal:
+    """who is acting on the admin API, and with what.
+
+    token_id is set only when an admin token authenticated the request, so
+    every mutation can name the credential rather than just the account.
+    """
+
+    account: Account
+    token_id: str | None = None
+
+    @property
+    def actor(self) -> str:
+        if self.token_id:
+            return f"{self.account.id} via token {self.token_id}"
+        return self.account.id
+
+
+def _bearer_token(request: Request) -> Optional[str]:
+    """the Bearer credential on the request, if it carries one.
+
+    another scheme (a fronting proxy's own basic auth) is ignored rather than
+    refused: it grants nothing here, and rejecting it would lock an operator
+    out of a session that was working.
+    """
+    header = request.headers.get("authorization")
+    if not header:
+        return None
+    scheme, _, value = header.partition(" ")
+    if scheme.lower() != "bearer":
+        return None
+    return value.strip() or None
+
+
+async def get_admin_principal(request: Request) -> AdminPrincipal:
+    """administrator for the request: an admin token, else the login cookie.
+
+    a Bearer credential that fails is a refusal, never a fall-through to the
+    cookie: an explicitly presented credential decides the request.
+    """
+    if settings.resolved_auth_mode != "native":
+        raise HTTPException(status_code=404, detail="native authentication is not enabled")
+    raw = _bearer_token(request)
+    if raw is None:
+        return AdminPrincipal(account=await get_admin_account(request))
+
+    from app.services.account_store import get_account_store
+    from app.services.auth_token_store import get_auth_token_store
+
+    resolved = get_auth_token_store().resolve_admin_token(raw)
+    if resolved is None:
+        raise HTTPException(status_code=401, detail="not authenticated")
+    account_id, token_id = resolved
+    account = get_account_store().get(account_id)
+    # the token carries no authority its issuer has lost: a disabled or
+    # demoted account takes its tokens down with it, checked live so it
+    # applies however the account changed
+    if account is None or account.disabled or not account.is_admin:
+        raise HTTPException(status_code=401, detail="not authenticated")
+    return AdminPrincipal(account=account, token_id=token_id)
+
+
+async def get_admin_session_principal(request: Request) -> AdminPrincipal:
+    """administrator from an interactive login only.
+
+    guards what a credential that skips the second factor must not reach. a
+    Bearer token here simply is not a login, so the cookie check refuses it.
+    """
+    return AdminPrincipal(account=await get_admin_account(request))
 
 
 async def require_instance_admin(request: Request):

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+# an upper bound on a requested lifetime, so a typo cannot mint a
+# ten-thousand-year credential that reads as deliberate
+MAX_ADMIN_TOKEN_DAYS = 3650
 
 
 class AuthStatusResponse(BaseModel):
@@ -86,3 +90,28 @@ class AdminResetPasswordRequest(BaseModel):
 
 class AdminUserListResponse(BaseModel):
     users: list[AccountResponse]
+
+
+class AdminTokenRequest(BaseModel):
+    # free-text note so an operator can tell one credential from another
+    label: str = Field(default="", max_length=100)
+    # omitted means no expiry; see docs/auth.md for why that is the default
+    expires_in_days: int | None = Field(default=None, gt=0, le=MAX_ADMIN_TOKEN_DAYS)
+
+
+class AdminTokenResponse(BaseModel):
+    id: str
+    account_id: str
+    label: str
+    created_at: str
+    expires_at: str | None
+    last_used_at: str | None
+
+
+class AdminTokenIssuedResponse(AdminTokenResponse):
+    # the raw credential, returned by the issuing call and never again
+    token: str
+
+
+class AdminTokenListResponse(BaseModel):
+    tokens: list[AdminTokenResponse]

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -78,6 +78,7 @@ class AdminCreateUserRequest(BaseModel):
     # import path: verify-as-is bcrypt ($2a/$2b/$2y) or native $scrypt$
     password_hash: str | None = None
     id: str | None = None
+    # session only: an admin token is refused rather than downgraded
     is_admin: bool = False
     totp_secret: str | None = None  # base32
     backup_code_hashes: list[str] | None = None

--- a/backend/app/services/auth_token_store.py
+++ b/backend/app/services/auth_token_store.py
@@ -1,12 +1,22 @@
 """auth tokens in auth_tokens.json at the storage root.
 
-tokens are opaque secrets.token_urlsafe values stored only as sha256 hashes
-with an expiry. lifetime is 14 days, sliding: use extends expiry, persisted
-at most hourly so routine requests do not rewrite the file.
+tokens are opaque secrets.token_urlsafe values stored only as sha256 hashes.
+two kinds share the file:
+
+login tokens back the browser cookie. lifetime is 14 days, sliding: use
+extends expiry, persisted at most hourly so routine requests do not rewrite
+the file.
+
+admin tokens authenticate automation to the admin API. they carry a handle so
+one can be revoked without touching the rest, never slide, and by default
+never expire. the two kinds are never interchangeable: each resolver only
+accepts its own, so a cookie value is not a bearer credential and an admin
+token pasted into the cookie authenticates nothing.
 """
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
 import secrets
@@ -26,11 +36,23 @@ TOKEN_LIFETIME = timedelta(days=14)
 # skip the disk write when sliding would move expiry by less than this
 _SLIDE_WRITE_THRESHOLD = timedelta(hours=1)
 
+LOGIN_KIND = "login"
+ADMIN_KIND = "admin"
+# marks the credential wherever it turns up: a secret scanner can match it,
+# and an operator can tell it from a cookie value at a glance
+ADMIN_TOKEN_PREFIX = "tfadm_"
+
 
 class AuthTokenRecord(BaseModel):
     account_id: str
     created_at: str
-    expires_at: str
+    # login tokens always expire; an admin token may be perpetual
+    expires_at: str | None
+    kind: str = LOGIN_KIND
+    # admin tokens only: the handle revocation names, and operator context
+    token_id: str = ""
+    label: str = ""
+    last_used_at: str | None = None
 
 
 def _hash_token(raw: str) -> str:
@@ -77,13 +99,14 @@ class AuthTokenStore:
         now = self._now()
         expired = [
             h for h, r in self._tokens.items()
-            if datetime.fromisoformat(r.expires_at) <= now
+            if r.expires_at is not None and datetime.fromisoformat(r.expires_at) <= now
         ]
         for h in expired:
             del self._tokens[h]
 
     def issue(self, account_id: str) -> str:
-        """create a token for the account; returns the raw value (never stored)"""
+        """create a login token for the account; returns the raw value
+        (never stored)"""
         raw = secrets.token_urlsafe(32)
         now = self._now()
         with self._lock:
@@ -97,12 +120,13 @@ class AuthTokenStore:
         return raw
 
     def resolve(self, raw: str) -> Optional[str]:
-        """account id for a valid token, sliding its expiry; none otherwise"""
+        """account id for a valid login token, sliding its expiry; none
+        otherwise. an admin token presented here is not a login."""
         token_hash = _hash_token(raw)
         now = self._now()
         with self._lock:
             record = self._tokens.get(token_hash)
-            if record is None:
+            if record is None or record.kind != LOGIN_KIND:
                 return None
             expires_at = datetime.fromisoformat(record.expires_at)
             if expires_at <= now:
@@ -116,23 +140,130 @@ class AuthTokenStore:
             return record.account_id
 
     def revoke(self, raw: str):
+        """drop a login token (logout)"""
+        token_hash = _hash_token(raw)
         with self._lock:
-            if self._tokens.pop(_hash_token(raw), None) is not None:
+            record = self._tokens.get(token_hash)
+            if record is not None and record.kind == LOGIN_KIND:
+                del self._tokens[token_hash]
                 self._save()
 
     def revoke_for_account(self, account_id: str, keep_raw: str | None = None):
-        """drop every token for the account, optionally keeping one (the
-        caller's own, e.g. after a self-service password change)"""
+        """drop every login token for the account, optionally keeping one (the
+        caller's own, e.g. after a self-service password change).
+
+        admin tokens are deliberately left alone. they are not browser
+        sessions: a password rotation is not evidence that a provisioning
+        credential leaked, and silently breaking automation on every password
+        change would teach operators to avoid rotating. revoke them
+        explicitly, or disable the account to make them inert at once.
+        """
         keep_hash = _hash_token(keep_raw) if keep_raw else None
         with self._lock:
             doomed = [
                 h for h, r in self._tokens.items()
-                if r.account_id == account_id and h != keep_hash
+                if r.account_id == account_id and r.kind == LOGIN_KIND and h != keep_hash
             ]
             for h in doomed:
                 del self._tokens[h]
             if doomed:
                 self._save()
+
+    def revoke_all_for_account(self, account_id: str):
+        """drop everything the account holds, of either kind. for deletion:
+        the account is gone, so nothing issued under it may outlive it"""
+        with self._lock:
+            doomed = [h for h, r in self._tokens.items() if r.account_id == account_id]
+            for h in doomed:
+                del self._tokens[h]
+            if doomed:
+                self._save()
+
+    # --- admin tokens ---
+
+    def issue_admin_token(
+        self, account_id: str, label: str = "", expires_at: datetime | None = None
+    ) -> tuple[AuthTokenRecord, str]:
+        """mint an admin token; returns (record, raw). the raw value is never
+        stored and cannot be recovered afterwards."""
+        raw = ADMIN_TOKEN_PREFIX + secrets.token_urlsafe(32)
+        now = self._now()
+        with self._lock:
+            self._purge_expired_locked()
+            taken = {r.token_id for r in self._tokens.values()}
+            token_id = secrets.token_hex(8)
+            while token_id in taken:
+                token_id = secrets.token_hex(8)
+            record = AuthTokenRecord(
+                account_id=account_id,
+                created_at=now.isoformat(),
+                expires_at=expires_at.isoformat() if expires_at else None,
+                kind=ADMIN_KIND,
+                token_id=token_id,
+                label=label,
+            )
+            self._tokens[_hash_token(raw)] = record
+            self._save()
+        return record.model_copy(), raw
+
+    def resolve_admin_token(self, raw: str) -> Optional[tuple[str, str]]:
+        """(account_id, token_id) for a live admin token, else none.
+
+        compares with hmac.compare_digest over the whole admin set rather than
+        a dict lookup, and does not stop at the match: the value compared is
+        derived from a secret, and the set is small enough that a linear scan
+        costs nothing. expiry never slides, so using a token that was issued
+        with a deadline cannot push that deadline out.
+        """
+        computed = _hash_token(raw)
+        now = self._now()
+        with self._lock:
+            found: Optional[str] = None
+            for token_hash, record in self._tokens.items():
+                if record.kind != ADMIN_KIND:
+                    continue
+                if hmac.compare_digest(token_hash, computed):
+                    found = token_hash
+            if found is None:
+                return None
+            record = self._tokens[found]
+            if record.expires_at is not None and datetime.fromisoformat(record.expires_at) <= now:
+                del self._tokens[found]
+                self._save()
+                return None
+            previous = record.last_used_at
+            record.last_used_at = now.isoformat()
+            # same throttle as the sliding cookie: a busy provisioner must not
+            # rewrite the file on every call
+            if previous is None or now - datetime.fromisoformat(previous) >= _SLIDE_WRITE_THRESHOLD:
+                self._save()
+            return record.account_id, record.token_id
+
+    def list_admin_tokens(self) -> list[AuthTokenRecord]:
+        """every live admin token on the instance, oldest first.
+
+        instance-wide on purpose: whoever is containing a leak must be able to
+        see and revoke a credential another administrator issued. a read, so
+        expired records are filtered rather than deleted here.
+        """
+        now = self._now()
+        with self._lock:
+            records = [
+                r.model_copy()
+                for r in self._tokens.values()
+                if r.kind == ADMIN_KIND
+                and (r.expires_at is None or datetime.fromisoformat(r.expires_at) > now)
+            ]
+        return sorted(records, key=lambda r: r.created_at)
+
+    def revoke_admin_token(self, token_id: str) -> bool:
+        with self._lock:
+            for token_hash, record in self._tokens.items():
+                if record.kind == ADMIN_KIND and record.token_id == token_id:
+                    del self._tokens[token_hash]
+                    self._save()
+                    return True
+        return False
 
 
 _store: AuthTokenStore | None = None

--- a/backend/tests/test_admin_api_tokens.py
+++ b/backend/tests/test_admin_api_tokens.py
@@ -1,0 +1,486 @@
+"""admin API tokens: issue, use, revoke, and the boundaries around all three.
+
+these authenticate to the admin surface with no password and no second
+factor, so most of what follows checks what they cannot reach.
+"""
+import hmac
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from app.auth import AUTH_COOKIE_NAME
+from app.services.auth_token_store import ADMIN_TOKEN_PREFIX, get_auth_token_store
+from tests.conftest import set_auth_mode
+from tests.test_auth_native import create_user, login, setup_admin
+
+TOKENS = "/api/admin/tokens"
+USERS = "/api/admin/users"
+
+
+def issue_token(client, **body):
+    resp = client.post(TOKENS, json=body or {})
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def bearer(client, raw):
+    """a fresh client carrying only the token: no cookie, no session"""
+    fresh = TestClient(client.app)
+    fresh.headers["Authorization"] = f"Bearer {raw}"
+    return fresh
+
+
+def admin_with_token(client):
+    setup_admin(client)
+    issued = issue_token(client)
+    return issued, bearer(client, issued["token"])
+
+
+# --- issuing requires an administrator session ---
+
+
+def test_issue_requires_authentication(native_client):
+    setup_admin(native_client)
+    anonymous = TestClient(native_client.app)
+    assert anonymous.post(TOKENS, json={}).status_code == 401
+
+
+def test_issue_refuses_a_non_admin_account(native_client):
+    setup_admin(native_client)
+    create_user(native_client, email="member@example.com", password="member password")
+    member = TestClient(native_client.app)
+    assert login(member, "member@example.com", "member password").status_code == 200
+    assert member.post(TOKENS, json={}).status_code == 403
+
+
+def test_issuing_needs_no_body(native_client):
+    setup_admin(native_client)
+    resp = native_client.post(TOKENS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["label"] == ""
+
+
+def test_a_token_cannot_issue_another_token(native_client):
+    """containment: a leaked token must not be able to mint successors"""
+    _, api = admin_with_token(native_client)
+    assert api.post(TOKENS, json={}).status_code == 401
+
+
+def test_a_token_cannot_list_or_revoke_tokens(native_client):
+    issued, api = admin_with_token(native_client)
+    assert api.get(TOKENS).status_code == 401
+    assert api.delete(f"{TOKENS}/{issued['id']}").status_code == 401
+
+
+# --- the token authenticates to the admin API ---
+
+
+def test_token_creates_an_account(native_client):
+    _, api = admin_with_token(native_client)
+    resp = api.post(USERS, json={"email": "new@example.com", "password": "a new password"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["email"] == "new@example.com"
+
+
+def test_token_resets_a_password(native_client):
+    _, api = admin_with_token(native_client)
+    created = create_user(native_client, email="reset@example.com", password="old password 1")
+    resp = api.post(
+        f"{USERS}/{created['id']}/reset-password", json={"password": "brand new password"}
+    )
+    assert resp.status_code == 204
+    fresh = TestClient(native_client.app)
+    assert login(fresh, "reset@example.com", "brand new password").status_code == 200
+
+
+def test_token_lists_disables_and_enables_accounts(native_client):
+    _, api = admin_with_token(native_client)
+    created = create_user(native_client, email="member@example.com", password="member password")
+    assert api.get(USERS).status_code == 200
+    assert api.post(f"{USERS}/{created['id']}/disable").status_code == 200
+    assert api.post(f"{USERS}/{created['id']}/enable").status_code == 200
+
+
+def test_token_cannot_clear_two_factor(native_client):
+    """it authenticates without a second factor, so it cannot remove one"""
+    _, api = admin_with_token(native_client)
+    created = create_user(native_client, email="member@example.com", password="member password")
+    assert api.post(f"{USERS}/{created['id']}/clear-2fa").status_code == 401
+    assert native_client.post(f"{USERS}/{created['id']}/clear-2fa").status_code == 204
+
+
+def test_token_cannot_read_storage_stats(native_client):
+    _, api = admin_with_token(native_client)
+    assert api.get("/api/admin/storage-stats").status_code == 401
+
+
+# --- the token is not a login ---
+
+
+def test_token_is_rejected_on_the_login_flow(native_client):
+    issued, api = admin_with_token(native_client)
+    assert api.get("/api/auth/me").status_code == 401
+    assert api.post(
+        "/api/auth/password",
+        json={"current_password": "correct horse battery", "new_password": "another password"},
+    ).status_code == 401
+    assert api.post("/api/auth/2fa/enroll").status_code == 401
+
+
+def test_token_is_rejected_on_non_admin_routes(native_client):
+    _, api = admin_with_token(native_client)
+    assert api.get("/api/sessions").status_code == 401
+    assert api.get("/api/tools").status_code == 401
+    assert api.delete("/api/users/me").status_code == 401
+
+
+def test_token_presented_as_the_auth_cookie_does_not_authenticate(native_client):
+    issued, _ = admin_with_token(native_client)
+    impostor = TestClient(native_client.app)
+    impostor.cookies.set(AUTH_COOKIE_NAME, issued["token"])
+    assert impostor.get("/api/auth/me").status_code == 401
+    assert impostor.get(USERS).status_code == 401
+
+
+def test_login_cookie_presented_as_a_bearer_token_does_not_authenticate(native_client):
+    setup_admin(native_client)
+    raw_cookie = native_client.cookies.get(AUTH_COOKIE_NAME)
+    assert raw_cookie
+    assert bearer(native_client, raw_cookie).get(USERS).status_code == 401
+
+
+def test_an_invalid_bearer_never_falls_back_to_the_cookie(native_client):
+    """an explicit credential that fails is a refusal, not a fall-through"""
+    setup_admin(native_client)
+    native_client.headers["Authorization"] = "Bearer not-a-real-token"
+    try:
+        assert native_client.get(USERS).status_code == 401
+    finally:
+        del native_client.headers["Authorization"]
+
+
+def test_a_non_bearer_authorization_header_leaves_the_session_alone(native_client):
+    """a proxy's own basic auth must not lock an operator out of their session"""
+    setup_admin(native_client)
+    native_client.headers["Authorization"] = "Basic Zm9vOmJhcg=="
+    try:
+        assert native_client.get(USERS).status_code == 200
+    finally:
+        del native_client.headers["Authorization"]
+
+
+# --- revocation ---
+
+
+def test_revocation_takes_effect_immediately(native_client):
+    issued, api = admin_with_token(native_client)
+    assert api.get(USERS).status_code == 200
+    assert native_client.delete(f"{TOKENS}/{issued['id']}").status_code == 204
+    assert api.get(USERS).status_code == 401
+
+
+def test_revoking_an_unknown_token_is_a_404(native_client):
+    setup_admin(native_client)
+    assert native_client.delete(f"{TOKENS}/deadbeefdeadbeef").status_code == 404
+
+
+def test_revoking_a_token_does_not_log_the_issuer_out(native_client):
+    issued, _ = admin_with_token(native_client)
+    native_client.delete(f"{TOKENS}/{issued['id']}")
+    assert native_client.get("/api/auth/me").status_code == 200
+
+
+def test_logging_out_does_not_revoke_the_token(native_client):
+    _, api = admin_with_token(native_client)
+    assert native_client.post("/api/auth/logout").status_code == 204
+    assert api.get(USERS).status_code == 200
+
+
+def test_a_password_change_does_not_revoke_the_token(native_client):
+    """rotating a password is not a signal that the automation leaked"""
+    _, api = admin_with_token(native_client)
+    resp = native_client.post(
+        "/api/auth/password",
+        json={"current_password": "correct horse battery", "new_password": "a longer password"},
+    )
+    assert resp.status_code == 204
+    assert api.get(USERS).status_code == 200
+
+
+def test_an_admin_password_reset_does_not_revoke_the_target_account_tokens(native_client):
+    setup_admin(native_client)
+    other = create_user(
+        native_client, email="second@example.com", password="second password", is_admin=True
+    )
+    second = TestClient(native_client.app)
+    assert login(second, "second@example.com", "second password").status_code == 200
+    issued = issue_token(second)
+    api = bearer(native_client, issued["token"])
+
+    resp = native_client.post(
+        f"{USERS}/{other['id']}/reset-password", json={"password": "reset by the first"}
+    )
+    assert resp.status_code == 204
+    assert api.get(USERS).status_code == 200
+
+
+def test_deleting_an_account_purges_its_tokens(native_client):
+    setup_admin(native_client)
+    other = create_user(
+        native_client, email="second@example.com", password="second password", is_admin=True
+    )
+    second = TestClient(native_client.app)
+    assert login(second, "second@example.com", "second password").status_code == 200
+    issued = issue_token(second)
+    api = bearer(native_client, issued["token"])
+
+    assert second.delete("/api/users/me").status_code == 204
+    assert api.get(USERS).status_code == 401
+    stored = json.loads((get_auth_token_store().file_path).read_text())
+    assert all(r["account_id"] != other["id"] for r in stored.values())
+
+
+# --- the token carries no authority its issuer has lost ---
+
+
+def test_disabling_the_issuing_account_kills_its_tokens(native_client):
+    setup_admin(native_client)
+    other = create_user(
+        native_client, email="second@example.com", password="second password", is_admin=True
+    )
+    second = TestClient(native_client.app)
+    assert login(second, "second@example.com", "second password").status_code == 200
+    api = bearer(native_client, issue_token(second)["token"])
+    assert api.get(USERS).status_code == 200
+
+    assert native_client.post(f"{USERS}/{other['id']}/disable").status_code == 200
+    assert api.get(USERS).status_code == 401
+
+    # re-enabling restores it: disable is a suspension, not a revocation
+    assert native_client.post(f"{USERS}/{other['id']}/enable").status_code == 200
+    assert api.get(USERS).status_code == 200
+
+
+def test_a_demoted_account_token_stops_working(native_client):
+    from app.services.account_store import get_account_store
+
+    issued, api = admin_with_token(native_client)
+    assert api.get(USERS).status_code == 200
+
+    def demote(live):
+        live.is_admin = False
+        return live
+
+    account_id = native_client.get("/api/auth/me").json()["id"]
+    create_user(
+        native_client, email="second@example.com", password="second password", is_admin=True
+    )
+    get_account_store().mutate(account_id, demote)
+    assert api.get(USERS).status_code == 401
+
+
+# --- storage ---
+
+
+def test_the_raw_token_is_never_stored(native_client):
+    import hashlib
+
+    issued, _ = admin_with_token(native_client)
+    raw = issued["token"]
+    path = get_auth_token_store().file_path
+    contents = path.read_text()
+    assert raw not in contents
+    assert raw.removeprefix(ADMIN_TOKEN_PREFIX) not in contents
+    assert hashlib.sha256(raw.encode()).hexdigest() in contents
+
+
+def test_the_token_is_returned_once_and_never_again(native_client):
+    issued, _ = admin_with_token(native_client)
+    listing = native_client.get(TOKENS)
+    assert listing.status_code == 200
+    assert issued["token"] not in listing.text
+    entries = listing.json()["tokens"]
+    assert [e["id"] for e in entries] == [issued["id"]]
+    assert "token" not in entries[0]
+
+
+def test_the_token_never_reaches_the_logs(native_client, caplog):
+    with caplog.at_level(logging.DEBUG):
+        issued, api = admin_with_token(native_client)
+        api.post(USERS, json={"email": "logged@example.com", "password": "some password 1"})
+        api.get(USERS)
+    assert issued["token"] not in caplog.text
+
+
+def test_an_issued_token_carries_the_recognisable_prefix(native_client):
+    issued, _ = admin_with_token(native_client)
+    assert issued["token"].startswith(ADMIN_TOKEN_PREFIX)
+
+
+def test_the_listing_covers_every_administrator(native_client):
+    """a leak has to be containable by whoever is holding the incident"""
+    setup_admin(native_client)
+    mine = issue_token(native_client, label="mine")
+    create_user(
+        native_client, email="second@example.com", password="second password", is_admin=True
+    )
+    second = TestClient(native_client.app)
+    assert login(second, "second@example.com", "second password").status_code == 200
+    theirs = issue_token(second, label="theirs")
+
+    ids = {e["id"] for e in native_client.get(TOKENS).json()["tokens"]}
+    assert ids == {mine["id"], theirs["id"]}
+    assert native_client.delete(f"{TOKENS}/{theirs['id']}").status_code == 204
+
+
+# --- expiry ---
+
+
+def test_a_token_expires_when_asked_to(native_client):
+    setup_admin(native_client)
+    issued = issue_token(native_client, expires_in_days=1)
+    assert issued["expires_at"] is not None
+    api = bearer(native_client, issued["token"])
+    assert api.get(USERS).status_code == 200
+
+    store = get_auth_token_store()
+    store._now = lambda: datetime.now(timezone.utc) + timedelta(days=1, minutes=1)
+    assert api.get(USERS).status_code == 401
+
+
+def test_a_token_defaults_to_no_expiry(native_client):
+    setup_admin(native_client)
+    issued = issue_token(native_client)
+    assert issued["expires_at"] is None
+    store = get_auth_token_store()
+    store._now = lambda: datetime.now(timezone.utc) + timedelta(days=3650)
+    assert bearer(native_client, issued["token"]).get(USERS).status_code == 200
+
+
+def test_using_a_token_does_not_extend_its_expiry(native_client):
+    setup_admin(native_client)
+    issued = issue_token(native_client, expires_in_days=1)
+    api = bearer(native_client, issued["token"])
+    store = get_auth_token_store()
+
+    store._now = lambda: datetime.now(timezone.utc) + timedelta(hours=23)
+    assert api.get(USERS).status_code == 200
+    store._now = lambda: datetime.now(timezone.utc) + timedelta(days=1, minutes=1)
+    assert api.get(USERS).status_code == 401
+
+
+def test_an_expired_token_drops_out_of_the_listing(native_client):
+    setup_admin(native_client)
+    issue_token(native_client, expires_in_days=1)
+    store = get_auth_token_store()
+    store._now = lambda: datetime.now(timezone.utc) + timedelta(days=2)
+    assert native_client.get(TOKENS).json()["tokens"] == []
+
+
+@pytest.mark.parametrize("days", [0, -1, 3651])
+def test_a_nonsense_expiry_is_refused(native_client, days):
+    setup_admin(native_client)
+    assert native_client.post(TOKENS, json={"expires_in_days": days}).status_code == 422
+
+
+def test_use_is_recorded(native_client):
+    issued, api = admin_with_token(native_client)
+    assert native_client.get(TOKENS).json()["tokens"][0]["last_used_at"] is None
+    assert api.get(USERS).status_code == 200
+    assert native_client.get(TOKENS).json()["tokens"][0]["last_used_at"] is not None
+
+
+# --- comparison ---
+
+
+def test_the_stored_hash_is_compared_in_constant_time(native_client, monkeypatch):
+    import app.services.auth_token_store as store_mod
+
+    issued, api = admin_with_token(native_client)
+    real = hmac.compare_digest
+    calls = []
+
+    def counting(a, b):
+        calls.append((a, b))
+        return real(a, b)
+
+    monkeypatch.setattr(store_mod.hmac, "compare_digest", counting)
+    assert api.get(USERS).status_code == 200
+    assert calls, "resolving an admin token must compare hashes with hmac.compare_digest"
+
+
+def test_a_near_miss_token_is_refused(native_client):
+    issued, _ = admin_with_token(native_client)
+    raw = issued["token"]
+    mangled = raw[:-1] + ("A" if raw[-1] != "A" else "B")
+    assert bearer(native_client, mangled).get(USERS).status_code == 401
+
+
+# --- other modes ---
+
+
+@pytest.mark.parametrize("mode,secret", [("open", None), ("proxy", "proxy-secret")])
+def test_tokens_do_not_exist_outside_native_mode(native_client, monkeypatch, mode, secret):
+    issued, _ = admin_with_token(native_client)
+    set_auth_mode(monkeypatch, mode, secret)
+
+    api = bearer(native_client, issued["token"])
+    assert api.post(TOKENS, json={}).status_code == 404
+    assert api.get(TOKENS).status_code == 404
+    assert api.get(USERS).status_code == 404
+    assert api.post(USERS, json={"email": "x@example.com", "password": "a password"}).status_code == 404
+    # the proxy secret is a transport check, not a principal: it opens nothing here
+    api.headers["X-Proxy-Secret"] = secret or ""
+    assert api.get(USERS).status_code == 404
+
+
+# --- attribution ---
+
+
+def _lines(caplog, needle):
+    return [r.getMessage() for r in caplog.records if needle in r.getMessage()]
+
+
+def test_session_mutations_record_the_acting_administrator(native_client, caplog):
+    with caplog.at_level(logging.INFO):
+        admin = setup_admin(native_client)
+        created = create_user(native_client, email="member@example.com", password="member password")
+        native_client.post(f"{USERS}/{created['id']}/disable")
+        native_client.post(f"{USERS}/{created['id']}/enable")
+        native_client.post(f"{USERS}/{created['id']}/reset-password", json={"password": "reset password"})
+        native_client.post(f"{USERS}/{created['id']}/clear-2fa")
+
+    for verb in ("created account", "disabled account", "enabled account",
+                 "reset the password for account", "cleared 2FA on account"):
+        matching = _lines(caplog, verb)
+        assert matching, f"no log line for {verb}"
+        assert all(admin["id"] in line and created["id"] in line for line in matching), matching
+        assert all("via token" not in line for line in matching), matching
+
+
+def test_token_mutations_name_the_token(native_client, caplog):
+    admin = setup_admin(native_client)
+    issued = issue_token(native_client)
+    api = bearer(native_client, issued["token"])
+    with caplog.at_level(logging.INFO):
+        resp = api.post(USERS, json={"email": "member@example.com", "password": "member password"})
+        created = resp.json()
+        api.post(f"{USERS}/{created['id']}/disable")
+
+    for verb in ("created account", "disabled account"):
+        matching = _lines(caplog, verb)
+        assert matching, f"no log line for {verb}"
+        assert all(f"{admin['id']} via token {issued['id']}" in line for line in matching), matching
+
+
+def test_issue_and_revoke_are_recorded(native_client, caplog):
+    with caplog.at_level(logging.INFO):
+        admin = setup_admin(native_client)
+        issued = issue_token(native_client, label="provisioner")
+        native_client.delete(f"{TOKENS}/{issued['id']}")
+
+    assert _lines(caplog, f"admin {admin['id']} issued admin token {issued['id']}")
+    assert _lines(caplog, f"admin {admin['id']} revoked admin token {issued['id']}")

--- a/backend/tests/test_admin_api_tokens.py
+++ b/backend/tests/test_admin_api_tokens.py
@@ -484,3 +484,149 @@ def test_issue_and_revoke_are_recorded(native_client, caplog):
 
     assert _lines(caplog, f"admin {admin['id']} issued admin token {issued['id']}")
     assert _lines(caplog, f"admin {admin['id']} revoked admin token {issued['id']}")
+
+
+# --- a token cannot reach administrator authority ---
+#
+# a token authenticates with no password step and no second factor. every
+# test here covers a route by which the holder of one could obtain a session,
+# a successor credential, or control of an account carrying more authority
+# than the token itself.
+
+
+def test_token_cannot_create_an_administrator(native_client):
+    """the whole containment model rests on this: an administrator the token
+    minted is one it can then log in as, interactively, with everything"""
+    _, api = admin_with_token(native_client)
+    resp = api.post(
+        USERS,
+        json={"email": "escalated@example.com", "password": "a long enough password",
+              "is_admin": True},
+    )
+    assert resp.status_code == 403, resp.text
+    # refused, not quietly downgraded to a member account
+    emails = [u["email"] for u in native_client.get(USERS).json()["users"]]
+    assert "escalated@example.com" not in emails
+
+
+def test_token_still_creates_ordinary_accounts(native_client):
+    """the refusal is about the administrator bit, not about creating"""
+    _, api = admin_with_token(native_client)
+    resp = api.post(USERS, json={"email": "member@example.com", "password": "member password",
+                                 "is_admin": False})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["is_admin"] is False
+
+
+def test_token_cannot_reset_an_administrator_password(native_client):
+    """reset it and the holder logs in as that administrator interactively"""
+    _, api = admin_with_token(native_client)
+    other = create_user(native_client, email="second@example.com",
+                        password="second password", is_admin=True)
+
+    resp = api.post(f"{USERS}/{other['id']}/reset-password",
+                    json={"password": "seized by the token"})
+    assert resp.status_code == 403, resp.text
+
+    fresh = TestClient(native_client.app)
+    assert login(fresh, "second@example.com", "seized by the token").status_code == 401
+    assert login(fresh, "second@example.com", "second password").status_code == 200
+
+
+def test_token_cannot_reset_the_password_of_its_own_issuer(native_client):
+    _, api = admin_with_token(native_client)
+    issuer = native_client.get("/api/auth/me").json()
+    resp = api.post(f"{USERS}/{issuer['id']}/reset-password",
+                    json={"password": "seized by the token"})
+    assert resp.status_code == 403, resp.text
+
+
+def test_token_cannot_disable_an_administrator(native_client):
+    """disabling every other administrator locks out the humans who could
+    revoke the token"""
+    _, api = admin_with_token(native_client)
+    other = create_user(native_client, email="second@example.com",
+                        password="second password", is_admin=True)
+
+    assert api.post(f"{USERS}/{other['id']}/disable").status_code == 403
+    listed = {u["id"]: u for u in native_client.get(USERS).json()["users"]}
+    assert listed[other["id"]]["disabled"] is False
+
+
+def test_token_cannot_enable_an_administrator(native_client):
+    """restoring an administrator a human suspended is the same authority in
+    the other direction"""
+    _, api = admin_with_token(native_client)
+    other = create_user(native_client, email="second@example.com",
+                        password="second password", is_admin=True)
+    assert native_client.post(f"{USERS}/{other['id']}/disable").status_code == 200
+
+    assert api.post(f"{USERS}/{other['id']}/enable").status_code == 403
+    listed = {u["id"]: u for u in native_client.get(USERS).json()["users"]}
+    assert listed[other["id"]]["disabled"] is True
+
+
+def test_the_escalation_chain_is_blocked_at_its_first_step(native_client):
+    """mint an administrator, log in as it, mint a successor token, strip the
+    root administrator's second factor. it stops at the first request.
+    """
+    _, api = admin_with_token(native_client)
+    root = native_client.get("/api/auth/me").json()
+
+    assert api.post(USERS, json={"email": "escalated@example.com",
+                                 "password": "a long enough password",
+                                 "is_admin": True}).status_code == 403
+
+    session = TestClient(native_client.app)
+    assert login(session, "escalated@example.com", "a long enough password").status_code == 401
+    assert session.post(TOKENS, json={}).status_code == 401
+    assert session.post(f"{USERS}/{root['id']}/clear-2fa").status_code == 401
+
+
+def test_a_session_administrator_keeps_every_ability(native_client):
+    """the refusals are scoped to the credential, not to the operation"""
+    setup_admin(native_client)
+    other = create_user(native_client, email="second@example.com",
+                        password="second password", is_admin=True)
+    assert other["is_admin"] is True
+
+    assert native_client.post(f"{USERS}/{other['id']}/reset-password",
+                              json={"password": "reset by a session"}).status_code == 204
+    assert native_client.post(f"{USERS}/{other['id']}/disable").status_code == 200
+    assert native_client.post(f"{USERS}/{other['id']}/enable").status_code == 200
+    assert native_client.post(f"{USERS}/{other['id']}/clear-2fa").status_code == 204
+    assert native_client.post(TOKENS, json={}).status_code == 200
+
+    second = TestClient(native_client.app)
+    assert login(second, "second@example.com", "reset by a session").status_code == 200
+
+
+# --- the admin router denies by default ---
+
+
+def test_an_undeclared_route_on_the_admin_router_is_not_anonymous(native_client):
+    """the token and session split is declared per route, so the router needs
+    a default: a route added later without one must not be open to anyone.
+    """
+    from fastapi import APIRouter, FastAPI
+
+    import app.api.admin_routes as admin_routes
+
+    assert admin_routes.router.dependencies, "the admin router declares no default dependency"
+
+    probe = APIRouter(dependencies=admin_routes.router.dependencies)
+
+    @probe.get("/admin/undeclared")
+    def undeclared():
+        return {"reached": True}
+
+    app = FastAPI()
+    app.include_router(probe, prefix="/api")
+    setup_admin(native_client)
+
+    anonymous = TestClient(app)
+    assert anonymous.get("/api/admin/undeclared").status_code == 401
+
+    authed = TestClient(app)
+    authed.cookies.update(native_client.cookies)
+    assert authed.get("/api/admin/undeclared").status_code == 200

--- a/backend/tests/test_user_id_format.py
+++ b/backend/tests/test_user_id_format.py
@@ -1,0 +1,123 @@
+"""the id format contract, on every path that becomes a storage directory.
+
+python's ``$`` matches before a trailing newline, so an anchored-with-``$``
+expression accepts ``"<valid id>\n"``. a newline in a namespace is not
+cross-user exposure, but the namespace becomes a directory name under the
+storage root, and a newline there breaks shell globbing, log parsing, backup
+scripts, and anything that reads a list of namespaces a line at a time.
+"""
+import io
+import sys
+
+import pytest
+from starlette.testclient import TestClient
+
+from app import cli
+from app.auth import valid_user_id
+from app.services.account_store import get_account_store
+from tests.conftest import set_auth_mode
+from tests.test_auth_native import setup_admin
+
+CUID = "cjld2cjxh0000qzrmn831i7rn"
+UUID = "deadbeef-dead-4bee-8bee-deadbeefdead"
+EMAIL = "admin@example.com"
+PASSWORD = "correct horse battery"
+
+# every way whitespace can ride along on an otherwise well-formed id
+BAD = [
+    pytest.param(CUID + "\n", id="cuid-trailing-lf"),
+    pytest.param(UUID + "\n", id="uuid-trailing-lf"),
+    pytest.param("\n" + CUID, id="cuid-leading-lf"),
+    pytest.param("\n" + UUID, id="uuid-leading-lf"),
+    pytest.param(CUID[:12] + "\n" + CUID[13:], id="cuid-embedded-lf"),
+    pytest.param(UUID[:12] + "\n" + UUID[13:], id="uuid-embedded-lf"),
+    pytest.param(CUID + "\r\n", id="cuid-trailing-crlf"),
+    pytest.param(CUID + "\r", id="cuid-trailing-cr"),
+    pytest.param(CUID + "\t", id="cuid-trailing-tab"),
+    pytest.param(CUID + " ", id="cuid-trailing-space"),
+    pytest.param(UUID + " ", id="uuid-trailing-space"),
+]
+
+
+def namespaces_on_disk(root):
+    return sorted(p.name for p in root.iterdir() if p.is_dir())
+
+
+@pytest.mark.parametrize("raw", BAD)
+def test_validator_rejects_whitespace_around_an_id(raw):
+    assert valid_user_id(raw) is False
+
+
+def test_validator_still_accepts_both_clean_shapes():
+    assert valid_user_id(CUID) is True
+    assert valid_user_id(UUID) is True
+
+
+@pytest.mark.parametrize("raw", BAD)
+def test_admin_create_rejects_a_whitespace_id(native_client, auth_mode_settings, raw):
+    setup_admin(native_client)
+    before = namespaces_on_disk(auth_mode_settings)
+    count = get_account_store().count()
+
+    resp = native_client.post(
+        "/api/admin/users",
+        json={"email": "imported@example.com", "password": PASSWORD, "id": raw},
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert get_account_store().count() == count
+    assert namespaces_on_disk(auth_mode_settings) == before
+
+
+@pytest.mark.parametrize("raw", BAD)
+def test_cli_id_flag_rejects_whitespace(auth_mode_settings, monkeypatch, capsys, raw):
+    set_auth_mode(monkeypatch, "native")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(f"{PASSWORD}\n"))
+
+    code = cli.main(["create-admin", "--email", EMAIL, "--id", raw])
+
+    assert code == 2
+    assert "id" in capsys.readouterr().err
+    assert get_account_store().count() == 0
+
+
+@pytest.mark.parametrize("raw", BAD)
+def test_cli_storage_namespace_flag_rejects_whitespace(
+    auth_mode_settings, monkeypatch, capsys, raw
+):
+    set_auth_mode(monkeypatch, "native")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(f"{PASSWORD}\n"))
+    before = namespaces_on_disk(auth_mode_settings)
+
+    code = cli.main(["create-admin", "--email", EMAIL, "--storage-namespace", raw])
+
+    assert code == 2
+    assert "namespace" in capsys.readouterr().err
+    assert get_account_store().count() == 0
+    assert namespaces_on_disk(auth_mode_settings) == before
+
+
+@pytest.mark.parametrize("raw", BAD)
+def test_proxy_header_rejects_a_whitespace_id(auth_mode_settings, monkeypatch, raw):
+    """a wire-level parser would refuse a bare newline in a header value, so
+    this is the validator standing behind whatever the proxy hands over"""
+    import app.main as main_mod
+
+    set_auth_mode(monkeypatch, "proxy", proxy_secret="proxy-secret")
+    client = TestClient(main_mod.app)
+
+    resp = client.get(
+        "/api/bins", headers={"x-user-id": raw, "x-proxy-secret": "proxy-secret"}
+    )
+
+    assert resp.status_code == 400
+    assert namespaces_on_disk(auth_mode_settings) == []
+
+
+def test_email_expression_rejects_a_trailing_newline():
+    """normalise_email strips before matching, so this locks the expression's
+    own contract rather than the caller's"""
+    from app.api.auth_common import _EMAIL_RE
+
+    assert _EMAIL_RE.match("admin@example.com\n") is None
+    assert _EMAIL_RE.match("admin@example.com") is not None

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,7 +46,12 @@ pending token is still good.
 Administrator API tokens authenticate the user-management endpoints above with
 `Authorization: Bearer <token>`, without a password or second factor. They do
 not reach `clear-2fa`, the token endpoints themselves, `storage-stats`, or
-anything outside `/api/admin/users`. See [auth.md](auth.md).
+anything outside `/api/admin/users`.
+
+Within those endpoints a token cannot create an administrator (`is_admin: true`
+is `403`) or write to an account that is one, so create, disable, enable and
+reset-password apply to ordinary accounts only. Listing is unrestricted. An
+administrator session keeps all of it. See [auth.md](auth.md).
 
 ## Sessions (trace workflow)
 - `POST /api/upload` - upload image, auto-detect corners

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,7 +38,15 @@ pending token is still good.
 - `POST /api/admin/users/{id}/disable` - disable and revoke the account's tokens immediately
 - `POST /api/admin/users/{id}/enable` - re-enable
 - `POST /api/admin/users/{id}/reset-password` - set a new password, revoking tokens
-- `POST /api/admin/users/{id}/clear-2fa` - recovery for a lost authenticator
+- `POST /api/admin/users/{id}/clear-2fa` - recovery for a lost authenticator; administrator session only
+- `GET /api/admin/tokens` - list administrator API tokens; administrator session only
+- `POST /api/admin/tokens` - issue one, returning the raw value once; administrator session only
+- `DELETE /api/admin/tokens/{id}` - revoke one; administrator session only
+
+Administrator API tokens authenticate the user-management endpoints above with
+`Authorization: Bearer <token>`, without a password or second factor. They do
+not reach `clear-2fa`, the token endpoints themselves, `storage-stats`, or
+anything outside `/api/admin/users`. See [auth.md](auth.md).
 
 ## Sessions (trace workflow)
 - `POST /api/upload` - upload image, auto-detect corners

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -249,9 +249,9 @@ authenticates to part of the admin API with no password step and no second
 factor.
 
 Issuing one requires a logged-in administrator. There is no unauthenticated or
-bootstrap path to minting one, and a token cannot mint another: containing a
-leak means revoking what an administrator issued, with no chain of successors
-to chase.
+bootstrap path to minting one, and a token cannot mint another, directly or by
+creating an administrator that could: containing a leak means revoking what an
+administrator issued, with no chain of successors to chase.
 
 ```bash
 # log in, keeping the session cookie (a 2FA account redeems its code as usual)
@@ -295,22 +295,52 @@ still applies.
 | Endpoint | Token | Why |
 |-|-|-|
 | `GET /api/admin/users` | yes | Provisioning has to be able to check what already exists |
-| `POST /api/admin/users` | yes | The reason the credential exists |
-| `POST /api/admin/users/{id}/reset-password` | yes | Scripted recovery and rotation |
-| `POST /api/admin/users/{id}/disable`, `/enable` | yes | Deprovisioning is provisioning |
+| `POST /api/admin/users` | yes, never an administrator | The reason the credential exists |
+| `POST /api/admin/users/{id}/reset-password` | yes, not an administrator's | Scripted recovery and rotation |
+| `POST /api/admin/users/{id}/disable`, `/enable` | yes, not an administrator's | Deprovisioning is provisioning |
 | `POST /api/admin/users/{id}/clear-2fa` | no | See below |
 | `GET`, `POST`, `DELETE /api/admin/tokens` | no | A token must not mint or revoke credentials |
 | `GET /api/admin/storage-stats` | no | Not provisioning, and it enumerates every namespace on the instance |
 | Everything else under `/api` | no | A token is not a login |
 
-Clearing a second factor is the one account operation deliberately left out. A
-credential that authenticates without a second factor must not be able to
-remove second factors from accounts: combined with a password reset that would
-make every account on the instance takeable by whoever holds the token,
-including administrators who enrolled 2FA precisely to prevent it. Recovery for
-a lost authenticator stays an interactive act. The split is enforced by which
-dependency each route declares, so a route added later reaches nothing until
-someone opts it in.
+#### Administrator accounts sit outside a token's reach
+
+A token neither creates an administrator nor writes to an account that is one.
+`is_admin: true` on create is `403`, as is a password reset, disable or enable
+whose target is an administrator, the account that issued the token included.
+Ordinary accounts are untouched by the rule: creating, resetting, disabling and
+enabling those is the whole point of the credential. An administrator session
+keeps every one of these abilities.
+
+The refusal is explicit rather than a quiet downgrade to a member account,
+because a provisioning script that asked for an administrator and got a `200`
+would carry on believing it had one.
+
+Without that rule the rest of this table is decoration. A token that can set
+`is_admin` creates an account with no second factor, logs in as it
+interactively, and holds a session: successor tokens, clearing 2FA on anyone,
+storage stats, all of it. A token that can reset an administrator's password
+arrives at the same place in one step fewer. Disable and enable are excluded
+for a weaker reason, denial of service rather than escalation: suspending every
+other administrator leaves the people who could revoke the token unable to log
+in, and the rule is easier to rely on stated once than carved out per route.
+
+Clearing a second factor is left out on the same principle in a different
+shape. A credential that authenticates without a second factor must not be able
+to remove second factors from accounts, which combined with a password reset
+would make every ordinary account on the instance takeable by whoever holds the
+token. Recovery for a lost authenticator stays an interactive act.
+
+Reading is not restricted this way. `GET /api/admin/users` lists every account,
+administrators included. It confers no authority, provisioning needs it to see
+what already exists, and it is how a caller learns which accounts it may not
+write to.
+
+The split is enforced by which dependency each route declares, and the router
+declares the administrator check as its default, so a route added without one
+is authenticated rather than anonymous. Such a route is reachable by a token;
+one that must not be declares the session-only dependency, and both are then
+required for the request to proceed.
 
 A token is not a login. It does not authenticate `GET /api/auth/me`, the
 password or 2FA endpoints, or any session, tool, bin, or project route, and it

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -59,8 +59,9 @@ command below.
 | `AUTH_ALLOW_ACCOUNT_DATA_WITHOUT_LOGIN` | `false` | Permit `open` or `proxy` mode on an instance that already has native accounts. Refused by default (see below) |
 
 The auth cookie (`tracefinity_auth`) is HttpOnly, SameSite=Lax, with a 14-day
-sliding lifetime. Tokens are stored hashed in `{storage}/auth_tokens.json`;
-accounts live in `{storage}/users.json`. Back up both with your storage volume.
+sliding lifetime. Tokens are stored hashed in `{storage}/auth_tokens.json`,
+which also holds the administrator API tokens described below; accounts live in
+`{storage}/users.json`. Back up both with your storage volume.
 
 When serving the frontend from a different origin than the backend, set
 `CORS_ORIGINS` to the real frontend origin. Credentials are only sent to
@@ -80,6 +81,8 @@ The first account is the administrator. `/api/admin/users` covers the minimum
 management surface: list, create, disable and enable (disabling revokes the
 account's auth tokens immediately), reset password, and clear 2FA. Every
 account can change its own password; a password change logs out other devices.
+`/api/admin/tokens` issues and revokes the non-interactive credential described
+under [Administrator API tokens](#administrator-api-tokens).
 
 Disabling refuses with `409` when it would leave the instance with no enabled
 administrator. The check runs inside the account store under its lock, not in
@@ -234,6 +237,153 @@ over, set the variable for the one command: `docker exec -e AUTH_MODE=native
 
 Errors go to stderr. Neither the password, the stored hash, nor an imported
 TOTP secret is ever printed.
+
+## Administrator API tokens
+
+The first-run command above covers provisioning before anyone can log in.
+Ongoing administration has the same problem in a different place: a deployment
+that creates accounts from its own front end, an internal tool, or a
+provisioning script cannot drive a browser login, and cannot supply a second
+factor at all. An administrator API token is the credential for that. It
+authenticates to part of the admin API with no password step and no second
+factor.
+
+Issuing one requires a logged-in administrator. There is no unauthenticated or
+bootstrap path to minting one, and a token cannot mint another: containing a
+leak means revoking what an administrator issued, with no chain of successors
+to chase.
+
+```bash
+# log in, keeping the session cookie (a 2FA account redeems its code as usual)
+curl -sc cookies.txt -X POST http://localhost:8000/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"email":"you@example.com","password":"..."}'
+
+# issue the token; the raw value is in this response and nowhere else
+curl -sb cookies.txt -X POST http://localhost:8000/api/admin/tokens \
+  -H 'content-type: application/json' \
+  -d '{"label":"provisioner"}'
+```
+
+The response carries `token` once. It is stored only as a sha256 hash in
+`{storage}/auth_tokens.json`, alongside login tokens, so nothing can print it
+again: a lost token is revoked and reissued, not recovered. It never appears
+in a log line, an error, or any later response. Values carry a `tfadm_` prefix
+so a leaked one is recognisable in a repository or a CI log.
+
+Present it as a bearer credential:
+
+```bash
+curl -X POST http://localhost:8000/api/admin/users \
+  -H "Authorization: Bearer $TRACEFINITY_ADMIN_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"email":"new@example.com","password":"a new password"}'
+```
+
+`Authorization` is used rather than a bespoke header because every HTTP client
+already handles it, and because a browser never attaches it on its own, so a
+token cannot become an ambient credential the way a cookie is. It does not
+collide with `X-Proxy-Secret`, which authenticates a proxy rather than a
+person, or with the auth cookie. A request carrying a bearer
+token is decided by that token: an invalid one is `401` and never falls back
+to a cookie that happens to be present. An `Authorization` header in another
+scheme, such as a fronting proxy's own basic auth, is ignored and the cookie
+still applies.
+
+### What a token reaches
+
+| Endpoint | Token | Why |
+|-|-|-|
+| `GET /api/admin/users` | yes | Provisioning has to be able to check what already exists |
+| `POST /api/admin/users` | yes | The reason the credential exists |
+| `POST /api/admin/users/{id}/reset-password` | yes | Scripted recovery and rotation |
+| `POST /api/admin/users/{id}/disable`, `/enable` | yes | Deprovisioning is provisioning |
+| `POST /api/admin/users/{id}/clear-2fa` | no | See below |
+| `GET`, `POST`, `DELETE /api/admin/tokens` | no | A token must not mint or revoke credentials |
+| `GET /api/admin/storage-stats` | no | Not provisioning, and it enumerates every namespace on the instance |
+| Everything else under `/api` | no | A token is not a login |
+
+Clearing a second factor is the one account operation deliberately left out. A
+credential that authenticates without a second factor must not be able to
+remove second factors from accounts: combined with a password reset that would
+make every account on the instance takeable by whoever holds the token,
+including administrators who enrolled 2FA precisely to prevent it. Recovery for
+a lost authenticator stays an interactive act. The split is enforced by which
+dependency each route declares, so a route added later reaches nothing until
+someone opts it in.
+
+A token is not a login. It does not authenticate `GET /api/auth/me`, the
+password or 2FA endpoints, or any session, tool, bin, or project route, and it
+cannot be pasted into the auth cookie: the two kinds of token are stored
+together but resolved separately, and neither resolver accepts the other's.
+
+### Revoking
+
+```bash
+curl -sb cookies.txt http://localhost:8000/api/admin/tokens
+curl -sb cookies.txt -X DELETE http://localhost:8000/api/admin/tokens/<id>
+```
+
+Revocation takes effect on the next request. The listing is instance-wide, not
+per administrator, so whoever is dealing with a leak can see and revoke a
+credential another administrator issued. It reports the issuing account, the
+label, when the token was created and last used, and its expiry, never the
+token itself.
+
+Revoking a token does not log its issuer out, and logging out does not revoke
+the token. A password change, whether self-service or an administrator reset,
+revokes login tokens and leaves administrator API tokens alone: rotating a
+password is not evidence that a provisioning credential leaked, and quietly
+breaking automation on every rotation would teach operators not to rotate.
+Revoke a token explicitly when it needs to go.
+
+Disabling the issuing account makes its tokens inert immediately, because every
+one of them is checked against the live account on use. Enabling the account
+restores them: a disable is a suspension, not a revocation. Demoting the
+account out of `is_admin` has the same effect. Deleting the account destroys
+its tokens outright.
+
+### Expiry
+
+There is no expiry by default. Provisioning automation runs for as long as the
+deployment does, and a credential that silently stops working is a credential
+that fails in the middle of something. Pass `expires_in_days` at issue time
+when a bounded one is wanted:
+
+```bash
+curl -sb cookies.txt -X POST http://localhost:8000/api/admin/tokens \
+  -H 'content-type: application/json' \
+  -d '{"label":"migration", "expires_in_days": 7}'
+```
+
+Unlike the login cookie, an administrator API token never slides: using it
+does not push its deadline out, so a bounded credential stays bounded.
+
+Nothing needs configuring to use any of this, and there is no rate limit on
+token authentication. The credential is 256 bits of `secrets.token_urlsafe`
+compared against stored hashes in constant time with no oracle to work
+against, so guessing one is not an attack that a limit would help with, and a
+limit keyed on anything a caller controls would hand an attacker a way to lock
+out an operator's automation. Password login stays rate limited because
+passwords are not 256 bits of randomness.
+
+Tokens exist in `native` mode only. In `open` and `proxy` mode the whole
+`/api/admin/users` surface returns `404` as it always has, bearer credential or
+not, so nothing here extends `PROXY_SECRET` or has to be unwound when `proxy`
+mode goes.
+
+### Attribution
+
+Every administrative mutation is logged with the account that made it and, when
+a token was used, the token:
+
+```
+admin 3f2a... created account 9b1c...
+admin 3f2a... via token 7d41... created account 9b1c...
+```
+
+Account creation, disable, enable, password reset and clearing 2FA all record
+this, as do issuing and revoking tokens.
 
 ## What stays public in native mode
 


### PR DESCRIPTION
## Summary

- Every administrative endpoint resolved identity from the auth cookie, so an automated process could not call the admin API without driving an interactive login, which is impossible for an account with a second factor enabled. Deployments that provision accounts programmatically had no way to authenticate.
- Administrators can now issue bearer tokens (`Authorization: Bearer tfadm_…`) scoped to account management: list, create, disable, enable, reset password. Issued only from an authenticated administrator session, stored hashed, individually revocable with effect on the next request, optional expiry that never slides.
- A token holds strictly less authority than the session that issued it: it neither creates an administrator nor writes to an account that is one. Clear-2FA, the token endpoints themselves and instance storage statistics stay session-only.
- Disabling or demoting the issuing account makes its tokens inert immediately; deleting it revokes them. A password change no longer revokes them, so automation survives routine credential rotation, while login sessions are still revoked as before.

## Notes for review

The containment rule is one invariant rather than a set of per-route exceptions, checked against the live record inside the account store lock. It exists because a credential that bypasses the second factor must not be able to remove second factors, reset an administrator's password, or mint an administrator it could then log in as: any of those turns a scoped token back into full authority.

Also here: `_USER_ID_RE` and `_EMAIL_RE` anchored with `\Z` rather than `$`. Python's `$` matches before a trailing newline, so an id ending in one previously passed validation and produced a storage directory with an embedded newline. That expression is the path-safety contract for anything that becomes a directory name.

## Test evidence

`backend/venv/bin/python -m pytest` 728 passed (617 before this branch)
`make lint` 0 errors, 9 pre-existing warnings in untouched files

Coverage includes every route's response to a token versus a session, bearer and cookie precedence, revocation and expiry, the disabled and demoted issuing account, hashing at rest, and the escalation chains above. Security-critical tests were mutation-checked; reverting a guard, weakening it to one alternative, or turning refusal into a silent downgrade each fail the suite.

Closes #205