### PR TITLE
fix(auth): refuse a namespace claim onto an occupied directory

### DIFF
--- a/backend/app/api/admin_routes.py
+++ b/backend/app/api/admin_routes.py
@@ -13,11 +13,15 @@ credential that authenticates without a second factor. the router declares
 the first as its default, so a route added without an explicit dependency is
 authenticated rather than anonymous.
 
-across the routes a token does reach, one further rule holds: a token neither
-creates an administrator nor writes to an account that is one. a token
+across the routes a token does reach, two further rules hold: a token neither
+creates an administrator nor writes to an account that is one, and a token
+does not open an account onto storage that already holds files. a token
 authenticates with no password step and no second factor, so an administrator
 it could mint or seize is an interactive login it could take, and every
-containment decision here would fall with it.
+containment decision here would fall with it; and storage it could adopt is
+another party's data it could read and write by logging in as the account it
+just made. both are enforced against the principal, so a route added here
+that takes either from a request body must apply them too.
 
 every mutation logs principal.actor, which names the account and, when a
 token was used, the token.
@@ -81,11 +85,31 @@ def _refuse_token_write_to_admin(principal: AdminPrincipal, live: Account) -> No
     who could revoke the token. checked against the live record inside the
     store lock, so it cannot race a change to the target's admin bit.
     """
-    if principal.token_id is None or not live.is_admin:
+    if not principal.is_token or not live.is_admin:
         return
     raise HTTPException(
         status_code=403,
         detail="an admin token cannot modify an administrator account; "
+        "use an administrator session",
+    )
+
+
+def _refuse_token_storage_adoption(principal: AdminPrincipal) -> None:
+    """stop an admin token opening a new account onto occupied storage.
+
+    adoption exists for an operator restoring an account onto storage carried
+    over with it, which is a deliberate act on data they are placing there. a
+    token is an unattended secret with no password step and no second factor,
+    and nothing it legitimately provisions needs to inherit files already on
+    the volume: whoever holds one could otherwise name any unmarked namespace,
+    create an account onto it and log in as that account to read and write
+    another party's data. a session administrator does the restore instead.
+    """
+    if not principal.is_token:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail="an admin token cannot adopt existing storage; "
         "use an administrator session",
     )
 
@@ -100,7 +124,7 @@ def list_users(principal: AdminPrincipal = Depends(get_admin_principal)):
 def create_user(
     req: AdminCreateUserRequest, principal: AdminPrincipal = Depends(get_admin_principal)
 ):
-    if req.is_admin and principal.token_id is not None:
+    if req.is_admin and principal.is_token:
         # refused rather than downgraded: a provisioning script that asked for
         # an administrator must not be told it got one
         raise HTTPException(
@@ -108,6 +132,11 @@ def create_user(
             detail="an admin token cannot create an administrator; "
             "use an administrator session",
         )
+    if req.adopt_existing_storage:
+        # checked on the request field, not on whether the namespace happens
+        # to be occupied, so the refusal does not depend on the state of the
+        # volume at the moment the call lands
+        _refuse_token_storage_adoption(principal)
     # validate everything before touching the store: a partial failure must
     # leave nothing behind
     email = normalise_email(req.email)

--- a/backend/app/api/admin_routes.py
+++ b/backend/app/api/admin_routes.py
@@ -62,7 +62,7 @@ from app.services import namespace_tombstones, secret_box
 from app.services.account_store import DuplicateAccountError, get_account_store
 from app.services.auth_token_store import get_auth_token_store
 from app.services.login_rate_limit import login_limiter
-from app.services.namespace_tombstones import NamespaceDeletionPendingError
+from app.services.namespace_tombstones import NamespaceNotClaimableError
 from app.services.password_hashing import hash_password, is_supported_hash
 
 logger = logging.getLogger(__name__)
@@ -164,8 +164,14 @@ def create_user(
         backup_code_hashes=backup_hashes,
     )
     try:
-        namespace_tombstones.claim(account.storage_namespace)
-    except NamespaceDeletionPendingError as exc:
+        # the namespace is the account id, so a supplied id can land on a
+        # directory that already holds another account's files. refuse unless
+        # the caller is importing an account back onto storage it owns and
+        # says so
+        namespace_tombstones.claim(
+            account.storage_namespace, adopt_existing=req.adopt_existing_storage
+        )
+    except NamespaceNotClaimableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     try:
         store.create(account)

--- a/backend/app/api/auth_routes.py
+++ b/backend/app/api/auth_routes.py
@@ -45,7 +45,7 @@ from app.services import namespace_tombstones, secret_box, totp
 from app.services.account_store import get_account_store
 from app.services.auth_token_store import get_auth_token_store
 from app.services.login_rate_limit import login_limiter
-from app.services.namespace_tombstones import NamespaceDeletionPendingError
+from app.services.namespace_tombstones import NamespaceNotClaimableError
 from app.services.password_hashing import (
     dummy_verify,
     hash_password,
@@ -186,10 +186,13 @@ def setup_first_admin(req: SetupRequest, response: Response):
         storage_namespace="default",
     )
     # the claim is what makes a leftover default namespace dangerous, so it is
-    # checked before an account is created that would point at it
+    # checked before an account is created that would point at it. adopting is
+    # the point of this route: it exists to take a single-user install into
+    # authenticated use with its library intact, and it only opens on an
+    # instance with no accounts. a tombstone still refuses it
     try:
-        namespace_tombstones.claim(account.storage_namespace)
-    except NamespaceDeletionPendingError as exc:
+        namespace_tombstones.claim(account.storage_namespace, adopt_existing=True)
+    except NamespaceNotClaimableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     if not get_account_store().create_first_admin(account):
         raise HTTPException(status_code=409, detail="setup has already been completed")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -91,6 +91,17 @@ class AdminPrincipal:
     token_id: str | None = None
 
     @property
+    def is_token(self) -> bool:
+        """whether an admin token, rather than a login session, authenticated.
+
+        the one discriminator the token restrictions test, so they cannot
+        drift apart. only the token branch of get_admin_principal ever sets
+        token_id, and it sets it from a record whose field is a str, so the
+        default None means a session and nothing else.
+        """
+        return self.token_id is not None
+
+    @property
     def actor(self) -> str:
         if self.token_id:
             return f"{self.account.id} via token {self.token_id}"

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -31,7 +31,7 @@ from app.config import ensure_user_dirs, settings
 from app.models.accounts import Account
 from app.services import namespace_tombstones, secret_box
 from app.services.account_store import get_account_store
-from app.services.namespace_tombstones import NamespaceDeletionPendingError
+from app.services.namespace_tombstones import NamespaceNotClaimableError
 from app.services.password_hashing import hash_password, is_supported_hash
 
 EXIT_OK = 0
@@ -276,8 +276,12 @@ def _create_admin(args: argparse.Namespace) -> int:
             backup_code_hashes=backup_hashes,
         )
         try:
-            namespace_tombstones.claim(account.storage_namespace)
-        except NamespaceDeletionPendingError as exc:
+            # adopting is what this command is for: the default namespace holds
+            # a single-user install's library, and --storage-namespace names
+            # storage the account already owned elsewhere. both are typed by an
+            # operator on an instance with no accounts. a tombstone still refuses
+            namespace_tombstones.claim(account.storage_namespace, adopt_existing=True)
+        except NamespaceNotClaimableError as exc:
             raise CliError(str(exc)) from exc
         if not get_account_store().create_first_admin(account):
             raise CliError("an account was created concurrently; nothing was changed", EXIT_EXISTS)

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -83,6 +83,10 @@ class AdminCreateUserRequest(BaseModel):
     totp_secret: str | None = None  # base32
     backup_code_hashes: list[str] | None = None
     created_at: str | None = None
+    # import only: open the account onto a storage namespace that already
+    # holds files, which is otherwise refused because the id names a
+    # directory that may be another account's
+    adopt_existing_storage: bool = False
 
 
 class AdminResetPasswordRequest(BaseModel):

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -85,7 +85,8 @@ class AdminCreateUserRequest(BaseModel):
     created_at: str | None = None
     # import only: open the account onto a storage namespace that already
     # holds files, which is otherwise refused because the id names a
-    # directory that may be another account's
+    # directory that may be another account's. an administrator session only;
+    # an admin token asking for it is refused
     adopt_existing_storage: bool = False
 
 

--- a/backend/app/services/namespace_tombstones.py
+++ b/backend/app/services/namespace_tombstones.py
@@ -1,17 +1,26 @@
-"""markers for storage namespaces whose deletion did not finish.
+"""the rule for handing a storage namespace to a new owner.
 
-deleting a user destroys the identity that owns a namespace before it
-destroys the files, so a failed rmtree, or a process killed between the two
-steps, leaves a directory with no owner. that namespace is then claimable:
-`default` by the next first-run administrator, and an account id by an admin
-create that supplies the same id. either way a new owner inherits the
-previous owner's files.
+a namespace is a directory of one party's files, and an account whose
+storage namespace points at it can read and write all of them. so a claim is
+refused whenever the directory already holds files, and allowed when it is
+empty or absent, which is the ordinary case.
 
-the marker is written before anything is destroyed, and lives beside the
-namespace rather than inside it, so the rmtree meant to clear it cannot
-remove the marker first and leave the files behind. it outlives the process,
-so a claim-time check covers a kill between the two steps that no in-request
-compensation can reach.
+that turns on what is on the volume rather than on a marker, because the
+states that produce an occupied but unowned namespace do not all leave one.
+an account creation interrupted before its record landed leaves the
+directory it made, and a storage volume restored without its users.json
+leaves every namespace on it.
+
+markers cover the state that no directory inspection can explain. deleting a
+user destroys the identity that owns a namespace before it destroys the
+files, so a failed rmtree, or a process killed between the two steps, leaves
+files whose owner is gone. the marker is written before anything is
+destroyed, and lives beside the namespace rather than inside it, so the
+rmtree meant to clear it cannot remove the marker first and leave the files
+behind. it outlives the process, so a claim-time check covers a kill between
+the two steps that no in-request compensation can reach, and it distinguishes
+files an operator may deliberately adopt from files whose owner this instance
+already destroyed.
 """
 from __future__ import annotations
 
@@ -25,8 +34,8 @@ from app.config import settings
 _MARKER_PREFIX = ".pending-deletion-"
 
 
-class NamespaceDeletionPendingError(RuntimeError):
-    """files outlived their owner; the namespace must not be handed to anyone"""
+class NamespaceNotClaimableError(RuntimeError):
+    """the namespace holds files; handing it over would hand over the files"""
 
 
 def _marker_path(namespace: str) -> Path:
@@ -57,7 +66,10 @@ def holds_files(path: Path) -> bool:
 
     a partial rmtree, or a later request recreating the empty scaffolding,
     leaves directories with nothing in them, and there is nothing to inherit
-    there. a symlink counts as content even when it points at a directory:
+    there. anything else counts, at any depth and whatever its size: an empty
+    or hidden file is still a record that somebody was here, and a namespace
+    holding one is not the untouched directory it would otherwise look like.
+    a symlink counts as content even when it points at a directory:
     following it would report on a tree that is not this namespace's, and
     handing the link to a new owner hands them whatever it points at. so
     does anything that cannot be inspected, because an unreadable directory
@@ -83,21 +95,38 @@ def holds_files(path: Path) -> bool:
     return False
 
 
-def claim(namespace: str):
+def claim(namespace: str, *, adopt_existing: bool = False):
     """let a new owner take this namespace, or refuse it.
+
+    refuse when the directory holds files. a marker is not the condition,
+    only the reason: an unmarked namespace full of files is someone's data
+    just the same, and marking is the step an interrupted deletion is most
+    likely to have reached, not the step it is likely to have missed.
 
     a marked namespace with no files left only records a deletion that
     finished without clearing its marker, so the marker goes and the claim
-    proceeds. one that still holds files outlived its owner: refuse rather
-    than hand a new account someone else's data. an operator resolves it by
-    removing the directory, which is the deletion that was asked for.
+    proceeds. an operator resolves the refusal by removing the directory,
+    which for a marked namespace is the deletion that was asked for.
+
+    `adopt_existing` is for the callers whose purpose is to take over data
+    already on the volume: first-run setup claiming pre-auth single-user
+    data, and an import placing an account back on the storage it owned on a
+    previous instance. it never overrides a marker, because those files'
+    owner was destroyed here and no import means to inherit that.
     """
-    if not is_marked(namespace):
-        return
-    if holds_files(settings.storage_path / namespace):
-        raise NamespaceDeletionPendingError(
-            f"storage namespace '{namespace}' still holds files from a deletion "
-            "that did not finish; remove that directory from the storage volume "
-            "before creating an account that would claim it"
+    marked = is_marked(namespace)
+    if (marked or not adopt_existing) and holds_files(settings.storage_path / namespace):
+        if marked:
+            raise NamespaceNotClaimableError(
+                f"storage namespace '{namespace}' still holds files from a deletion "
+                "that did not finish; remove that directory from the storage volume "
+                "before creating an account that would claim it"
+            )
+        raise NamespaceNotClaimableError(
+            f"storage namespace '{namespace}' already holds files, and an account "
+            "created here would take over data it does not own; use a different "
+            "account id, or remove that directory from the storage volume, unless "
+            "adopting those files is the intent"
         )
-    clear(namespace)
+    if marked:
+        clear(namespace)

--- a/backend/tests/test_admin_api_tokens.py
+++ b/backend/tests/test_admin_api_tokens.py
@@ -12,6 +12,8 @@ import pytest
 from starlette.testclient import TestClient
 
 from app.auth import AUTH_COOKIE_NAME
+from app.services import namespace_tombstones
+from app.services.account_store import get_account_store
 from app.services.auth_token_store import ADMIN_TOKEN_PREFIX, get_auth_token_store
 from tests.conftest import set_auth_mode
 from tests.test_auth_native import create_user, login, setup_admin
@@ -599,6 +601,137 @@ def test_a_session_administrator_keeps_every_ability(native_client):
 
     second = TestClient(native_client.app)
     assert login(second, "second@example.com", "reset by a session").status_code == 200
+
+
+# --- a token cannot reach another party's storage ---
+#
+# the account id is the storage namespace, so a caller that chooses the id
+# chooses the directory. adoption opens an account onto one that already holds
+# files, which is a deliberate restore an operator performs on data they are
+# placing there, not something an unattended credential does.
+
+# valid cuid per auth._USER_ID_RE
+VICTIM_NAMESPACE = "cjld2cjxh0000qzrmn831i7rn"
+
+
+def _plant(storage, namespace):
+    """a namespace holding one party's tools, owned by no account here"""
+    ns = storage / namespace
+    ns.mkdir(parents=True, exist_ok=True)
+    (ns / "tools.json").write_text(json.dumps({
+        "t1": {
+            "id": "t1",
+            "name": "victim spanner",
+            "points": [],
+            "created_at": "2026-01-01T00:00:00",
+        }
+    }))
+    return ns
+
+
+def test_token_cannot_adopt_a_namespace_holding_another_party_files(
+    native_client, auth_mode_settings
+):
+    """the whole exploit in one test: name the namespace, adopt it, log in.
+
+    it stops at the first request, and the account the attacker would have
+    logged in as is never created, so the files stay unreachable.
+    """
+    _, api = admin_with_token(native_client)
+    _plant(auth_mode_settings, VICTIM_NAMESPACE)
+    assert namespace_tombstones.is_marked(VICTIM_NAMESPACE) is False
+
+    resp = api.post(USERS, json={
+        "id": VICTIM_NAMESPACE,
+        "email": "attacker@example.com",
+        "password": "a long enough password",
+        "adopt_existing_storage": True,
+    })
+    assert resp.status_code == 403, resp.text
+    assert "adopt existing storage" in resp.json()["detail"]
+
+    # refused, not quietly downgraded to a create that skipped the adoption
+    emails = [u["email"] for u in native_client.get(USERS).json()["users"]]
+    assert "attacker@example.com" not in emails
+    assert get_account_store().get(VICTIM_NAMESPACE) is None
+
+    # and there is no account to log in as, so the tools are unreachable
+    thief = TestClient(native_client.app)
+    assert login(thief, "attacker@example.com", "a long enough password").status_code == 401
+    assert thief.get("/api/tools").status_code == 401
+
+
+def test_the_refusal_does_not_depend_on_what_the_namespace_holds(native_client):
+    """asked on the request field, so an empty namespace answers the same.
+
+    a refusal that turned on the state of the volume would tell the holder
+    which namespaces are occupied, and would open a window between the check
+    and files arriving.
+    """
+    _, api = admin_with_token(native_client)
+    resp = api.post(USERS, json={
+        "id": VICTIM_NAMESPACE,
+        "email": "attacker@example.com",
+        "password": "a long enough password",
+        "adopt_existing_storage": True,
+    })
+    assert resp.status_code == 403, resp.text
+
+
+def test_token_still_creates_accounts_without_asking_to_adopt(native_client):
+    """the refusal is about the adoption, not about creating: ordinary
+    provisioning lands on an empty namespace and is untouched"""
+    _, api = admin_with_token(native_client)
+    resp = api.post(USERS, json={
+        "id": VICTIM_NAMESPACE,
+        "email": "member@example.com",
+        "password": "member password",
+    })
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["id"] == VICTIM_NAMESPACE
+
+
+def test_token_asking_for_both_an_administrator_and_adoption_is_refused(
+    native_client, auth_mode_settings
+):
+    """the two token rules do not cover for each other; either alone refuses"""
+    _, api = admin_with_token(native_client)
+    _plant(auth_mode_settings, VICTIM_NAMESPACE)
+
+    resp = api.post(USERS, json={
+        "id": VICTIM_NAMESPACE,
+        "email": "escalated@example.com",
+        "password": "a long enough password",
+        "is_admin": True,
+        "adopt_existing_storage": True,
+    })
+    assert resp.status_code == 403, resp.text
+    emails = [u["email"] for u in native_client.get(USERS).json()["users"]]
+    assert "escalated@example.com" not in emails
+
+
+def test_a_session_administrator_can_still_adopt(native_client, auth_mode_settings):
+    """restoring an account onto storage carried over with it stays available.
+
+    the CLI creates the first administrator only, so this endpoint is the only
+    way to put the second and later accounts back on their own data.
+    """
+    setup_admin(native_client)
+    _plant(auth_mode_settings, VICTIM_NAMESPACE)
+
+    resp = native_client.post(USERS, json={
+        "id": VICTIM_NAMESPACE,
+        "email": "restored@example.com",
+        "password": "a long enough password",
+        "adopt_existing_storage": True,
+    })
+    assert resp.status_code == 200, resp.text
+
+    restored = TestClient(native_client.app)
+    assert login(restored, "restored@example.com", "a long enough password").status_code == 200
+    tools = restored.get("/api/tools")
+    assert tools.status_code == 200, tools.text
+    assert [t["name"] for t in tools.json()["tools"]] == ["victim spanner"]
 
 
 # --- the admin router denies by default ---

--- a/backend/tests/test_namespace_deletion_tombstone.py
+++ b/backend/tests/test_namespace_deletion_tombstone.py
@@ -1,10 +1,10 @@
-"""a namespace whose files outlive their owner must not be claimable.
+"""a namespace holding one party's files must not be handed to another.
 
-native deletion removes the account record before the storage directory, so a
-failed rmtree, or a process killed between the two, leaves files with no owner.
-the reusable `default` namespace makes that a cross-tenant exposure: the store
-is empty again, first-run setup reopens, and the next administrator would
-inherit the previous owner's files.
+an account opens onto a storage namespace and can read and write everything
+under it, so claiming an occupied directory hands over its contents. the two
+ways a directory ends up occupied and unowned are covered here: a deletion
+that destroyed the account record and then failed to remove the files, which
+leaves a marker, and everything else, which does not.
 """
 import os
 import shutil
@@ -202,7 +202,7 @@ def test_a_namespace_holding_only_a_directory_symlink_is_refused(auth_mode_setti
     (namespace / "link").symlink_to(elsewhere, target_is_directory=True)
     namespace_tombstones.mark("default")
 
-    with pytest.raises(namespace_tombstones.NamespaceDeletionPendingError):
+    with pytest.raises(namespace_tombstones.NamespaceNotClaimableError):
         namespace_tombstones.claim("default")
     assert (elsewhere / "inner" / "canary.txt").read_text() == "private"
 
@@ -217,8 +217,136 @@ def test_a_namespace_that_cannot_be_inspected_is_refused(auth_mode_settings):
     os.chmod(unreadable, 0o000)
     namespace_tombstones.mark("default")
     try:
-        with pytest.raises(namespace_tombstones.NamespaceDeletionPendingError):
+        with pytest.raises(namespace_tombstones.NamespaceNotClaimableError):
             namespace_tombstones.claim("default")
     finally:
         os.chmod(unreadable, 0o700)
     assert (unreadable / "canary.txt").read_text() == "private"
+
+
+def test_an_unmarked_namespace_holding_files_is_not_claimable(
+    native_client, auth_mode_settings
+):
+    """the marker records that someone got as far as marking, nothing more.
+
+    an account creation interrupted before its record landed, or a restored
+    volume whose users.json did not come with it, leaves a namespace full of
+    one party's files and no marker at all. claiming it hands a new account
+    read and write access to them.
+    """
+    resp = native_client.post("/api/auth/setup", json=ADMIN)
+    assert resp.status_code == 200, resp.text
+    canary = _canary(auth_mode_settings, PROXY_USER)
+    assert namespace_tombstones.is_marked(PROXY_USER) is False
+
+    resp = native_client.post(
+        "/api/admin/users",
+        json={"id": PROXY_USER, "email": "user@example.com", "password": "a fine password"},
+    )
+    assert resp.status_code == 409, resp.text
+    assert "already holds files" in resp.json()["detail"]
+    assert canary.read_text() == "private"
+
+
+def test_a_refused_claim_creates_no_account(native_client, auth_mode_settings):
+    """the claim runs before the store write, so nothing half-lands"""
+    resp = native_client.post("/api/auth/setup", json=ADMIN)
+    assert resp.status_code == 200, resp.text
+    _canary(auth_mode_settings, PROXY_USER)
+    before = get_account_store().count()
+
+    resp = native_client.post(
+        "/api/admin/users",
+        json={"id": PROXY_USER, "email": "user@example.com", "password": "a fine password"},
+    )
+    assert resp.status_code == 409, resp.text
+    assert get_account_store().count() == before
+    assert get_account_store().get(PROXY_USER) is None
+    assert get_account_store().get_by_email("user@example.com") is None
+    # and the refused email is still free for a later, valid create
+    resp = native_client.post(
+        "/api/admin/users", json={"email": "user@example.com", "password": "a fine password"}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_an_unmarked_empty_namespace_stays_claimable(native_client, auth_mode_settings):
+    """the ordinary case: scaffolding with nothing in it is nobody's data"""
+    from app.config import ensure_user_dirs
+
+    ensure_user_dirs(auth_mode_settings / PROXY_USER)
+
+    resp = native_client.post("/api/auth/setup", json=ADMIN)
+    assert resp.status_code == 200, resp.text
+    resp = native_client.post(
+        "/api/admin/users",
+        json={"id": PROXY_USER, "email": "user@example.com", "password": "a fine password"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_a_zero_byte_file_counts_as_content(auth_mode_settings):
+    """size is not ownership: an empty file is still someone's, and a
+    namespace holding one is not the untouched directory it looks like"""
+    namespace = auth_mode_settings / PROXY_USER
+    (namespace / "uploads").mkdir(parents=True)
+    (namespace / "uploads" / ".hidden").touch()
+
+    with pytest.raises(namespace_tombstones.NamespaceNotClaimableError):
+        namespace_tombstones.claim(PROXY_USER)
+
+
+def test_admin_create_can_adopt_a_namespace_on_request(native_client, auth_mode_settings):
+    """importing an account from a prior system onto its own storage.
+
+    the refusal is about doing this by accident, so the deliberate form of it
+    stays available and says so in the request.
+    """
+    resp = native_client.post("/api/auth/setup", json=ADMIN)
+    assert resp.status_code == 200, resp.text
+    canary = _canary(auth_mode_settings, PROXY_USER)
+
+    resp = native_client.post(
+        "/api/admin/users",
+        json={
+            "id": PROXY_USER,
+            "email": "user@example.com",
+            "password": "a fine password",
+            "adopt_existing_storage": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert canary.read_text() == "private"
+
+
+def test_adopting_never_overrides_an_unfinished_deletion(native_client, auth_mode_settings):
+    """a marker means these files' owner was destroyed, which no import
+    intends to inherit; the operator removes the directory instead"""
+    resp = native_client.post("/api/auth/setup", json=ADMIN)
+    assert resp.status_code == 200, resp.text
+    canary = _canary(auth_mode_settings, PROXY_USER)
+    namespace_tombstones.mark(PROXY_USER)
+
+    resp = native_client.post(
+        "/api/admin/users",
+        json={
+            "id": PROXY_USER,
+            "email": "user@example.com",
+            "password": "a fine password",
+            "adopt_existing_storage": True,
+        },
+    )
+    assert resp.status_code == 409, resp.text
+    assert "did not finish" in resp.json()["detail"]
+    assert canary.read_text() == "private"
+
+
+def test_first_run_setup_still_claims_pre_auth_data(native_client, auth_mode_settings):
+    """the documented upgrade from open mode: the first administrator takes
+    over the single-user library in place, and no marker exists to allow it"""
+    canary = _canary(auth_mode_settings, "default")
+    assert namespace_tombstones.is_marked("default") is False
+
+    resp = native_client.post("/api/auth/setup", json=ADMIN)
+    assert resp.status_code == 200, resp.text
+    assert canary.read_text() == "private"

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -98,11 +98,19 @@ setup only opens on an empty account store: an instance left with accounts but
 no administrator could not be recovered. Deleting the last remaining account
 is allowed and returns the instance to first run.
 
+A namespace is claimable only when its directory is empty or absent. Creating
+an account onto a namespace that already holds files is refused with `409`,
+because the account would be able to read and write all of them. Remove that
+directory from the storage volume to release the namespace, or see the import
+option below when the files belong to the account being created.
+
 The account record goes before the stored data, so a storage failure part-way
 through can leave files with no owner. Deletion marks the namespace first and
-only unmarks it once the files are gone, and an account creation that would
-claim a marked namespace still holding files is refused with `409`. Remove
-that directory from the storage volume to release the namespace.
+only unmarks it once the files are gone. The marker survives a process that
+dies mid-deletion, which no directory inspection can otherwise explain, and it
+separates files an operator may deliberately claim from files whose owner this
+instance already destroyed: a marked namespace is refused even when the claim
+asks to adopt what is there.
 
 That refusal happens where a namespace is claimed, which is account creation.
 Proxy mode has no accounts: the namespace is whatever `X-User-Id` says, and
@@ -122,7 +130,10 @@ caller-supplied `id` (keeps storage keying), a `password_hash` in bcrypt
 (`$2a$`/`$2b$`/`$2y$`) or native `$scrypt$` form, a base32 `totp_secret`,
 `backup_code_hashes`, and `created_at`. Imports are validated before anything
 is written; a repeated import of the same id and email is a no-op and never
-overwrites. Imported bcrypt credentials are verified as-is and transparently
+overwrites. Restoring an account onto storage carried over from the prior
+system also needs `adopt_existing_storage: true`, which is what separates that
+from an id that collides with somebody else's directory by accident; the
+namespace is still refused if an unfinished deletion marked it. Imported bcrypt credentials are verified as-is and transparently
 rehashed to the native scheme on first successful login. The first
 administrator exists before that endpoint can be called, so the command below
 imports the same material for that one account.
@@ -199,8 +210,10 @@ authenticated use wants.
 
 The value becomes a directory name under the storage root, so it is held to
 the same format contract as `--id`, plus the literal `default`. Anything else
-is rejected. Whichever namespace is chosen, it is claimed on the same terms:
-a namespace whose deletion did not finish is refused.
+is rejected. Naming a namespace here is a deliberate claim on whatever it
+holds, which is what the option is for, so unlike `/api/admin/users` the
+command does not refuse a namespace that already has files in it. A namespace
+whose deletion did not finish is still refused.
 
 `--totp-secret` imports a second factor on the same terms as the admin create
 endpoint, through the same validation and the same encryption at rest, so the

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -133,7 +133,11 @@ is written; a repeated import of the same id and email is a no-op and never
 overwrites. Restoring an account onto storage carried over from the prior
 system also needs `adopt_existing_storage: true`, which is what separates that
 from an id that collides with somebody else's directory by accident; the
-namespace is still refused if an unfinished deletion marked it. Imported bcrypt credentials are verified as-is and transparently
+namespace is still refused if an unfinished deletion marked it. That flag
+needs an administrator session: an admin token asking for it is refused with
+`403`, on the same grounds as creating an administrator, because adopting a
+namespace means reading and writing whatever is already in it. Imported bcrypt
+credentials are verified as-is and transparently
 rehashed to the native scheme on first successful login. The first
 administrator exists before that endpoint can be called, so the command below
 imports the same material for that one account.
@@ -308,7 +312,7 @@ still applies.
 | Endpoint | Token | Why |
 |-|-|-|
 | `GET /api/admin/users` | yes | Provisioning has to be able to check what already exists |
-| `POST /api/admin/users` | yes, never an administrator | The reason the credential exists |
+| `POST /api/admin/users` | yes, never an administrator, never adopting storage | The reason the credential exists |
 | `POST /api/admin/users/{id}/reset-password` | yes, not an administrator's | Scripted recovery and rotation |
 | `POST /api/admin/users/{id}/disable`, `/enable` | yes, not an administrator's | Deprovisioning is provisioning |
 | `POST /api/admin/users/{id}/clear-2fa` | no | See below |
@@ -337,6 +341,26 @@ arrives at the same place in one step fewer. Disable and enable are excluded
 for a weaker reason, denial of service rather than escalation: suspending every
 other administrator leaves the people who could revoke the token unable to log
 in, and the rule is easier to rely on stated once than carved out per route.
+
+#### Occupied storage sits outside a token's reach
+
+A token cannot create an account onto a storage namespace that already holds
+files. `adopt_existing_storage: true` is `403` for a token whatever the
+namespace turns out to contain, so the answer does not depend on the state of
+the volume when the call lands. Creating an account onto an empty or absent
+namespace, which is every ordinary provisioning call, is unaffected.
+
+The account id is the namespace, so a caller that chooses the id chooses the
+directory. Adopting one that is occupied means the new account can read and
+write everything under it, and whoever holds the token can log in as the
+account it just created. Nothing a provisioning script legitimately does needs
+to inherit files already on the volume: the flag is there for an operator
+restoring an account onto storage they are carrying over with it, which is a
+deliberate act on data they are placing there themselves, and an administrator
+session is what performs it.
+
+An unmarked namespace is the case this covers. A marked one, whose owner this
+instance destroyed, is refused for everybody, session and token alike.
 
 Clearing a second factor is left out on the same principle in a different
 shape. A credential that authenticates without a second factor must not be able

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Hardens namespace claiming so a claim is refused when the target storage
directory already exists and holds files. An empty or absent namespace stays
claimable, which is the ordinary case.

Taking over data already on the volume remains possible where that is the
caller's explicit purpose, and is no longer the default.

## Test evidence

Backend and frontend suites pass, `make lint` clean. New tests cover the
refusal, the permitted paths, and that a refused claim leaves no partial
account. Verified by reverting the change and confirming the new tests fail.