### PR TITLE
Preserve approved return destinations through login

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -75,6 +75,22 @@ that encrypts every stored 2FA secret, and it overrides the generated file
 secret, so a short value makes `users.json` worth brute-forcing offline.
 Leaving it unset generates a strong one into the storage volume.
 
+### Returning after login
+
+An integration can open `/login?returnTo=<encoded-absolute-url>` to resume a
+page after login. The frontend server checks the destination against
+`AUTH_LOGIN_RETURN_ORIGINS`, a JSON array of exact origins, for example
+`["https://portal.example.com"]`. Set it in the frontend process environment
+(or the combined container environment). It is read at request time, so changing
+the list does not require rebuilding the frontend.
+
+The list defaults to empty. Missing, malformed, or unapproved destinations
+return to `/` as before. Entries must be HTTP or HTTPS origins without paths,
+queries, credentials, or a trailing slash; scheme and port must match exactly.
+Wildcards and relative destinations are not supported. The destination's path
+and query are preserved through password login, two-factor login, and an already
+authenticated visit. A first-run instance still opens `/setup`.
+
 ## Accounts and administration
 
 The first account is the administrator. `/api/admin/users` covers the minimum

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { FormEvent, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Alert } from '@/components/Alert'
+import { ApiError, getAuthStatus, login, loginTwoFactor, navigation } from '@/lib/api'
+
+const inputClass =
+  'w-full px-3 py-2 text-sm rounded-[7px] bg-surface border border-border text-text-primary focus:outline-none'
+
+export default function LoginForm({ returnTo = '/' }: { returnTo?: string }) {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [pendingToken, setPendingToken] = useState<string | null>(null)
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    getAuthStatus()
+      .then((status) => {
+        if (status.mode !== 'native' || status.authenticated) {
+          if (returnTo === '/') router.replace('/')
+          else navigation.afterLogin(returnTo)
+        }
+        else if (status.setup_required) router.replace('/setup')
+      })
+      .catch(() => {})
+  }, [router, returnTo])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setBusy(true)
+    try {
+      if (pendingToken) {
+        await loginTwoFactor(pendingToken, code)
+        navigation.afterLogin(returnTo)
+        return
+      }
+      const result = await login(email, password)
+      if (result.pending && result.pending_token) {
+        setPendingToken(result.pending_token)
+        return
+      }
+      navigation.afterLogin(returnTo)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401 && pendingToken) {
+        setError(err.message)
+        // an expired or exhausted pending token means starting over; a wrong
+        // code leaves the token usable, so stay on the code step
+        if (err.code === 'pending_login_invalid') {
+          setPendingToken(null)
+          setCode('')
+        }
+      } else {
+        setError(err instanceof ApiError ? err.message : 'login failed')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto mt-16">
+      <div className="glass-card p-6">
+        <h1 className="text-base font-semibold text-text-primary mb-1">Log in</h1>
+        <p className="text-xs text-text-muted mb-4">
+          {pendingToken
+            ? 'Enter a code from your authenticator app, or a backup code.'
+            : 'Sign in to your Tracefinity account.'}
+        </p>
+        {error && (
+          <div className="mb-3">
+            <Alert variant="error">{error}</Alert>
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-3">
+          {pendingToken ? (
+            <input
+              className={inputClass}
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="123456"
+              autoComplete="one-time-code"
+              autoFocus
+              aria-label="Two-factor code"
+            />
+          ) : (
+            <>
+              <input
+                className={inputClass}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Email"
+                autoComplete="username"
+                required
+                aria-label="Email"
+              />
+              <input
+                className={inputClass}
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Password"
+                autoComplete="current-password"
+                required
+                aria-label="Password"
+              />
+            </>
+          )}
+          <button type="submit" disabled={busy} className="btn-primary w-full py-2 text-sm">
+            {pendingToken ? 'Verify' : 'Log in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import LoginPage from './page'
+import LoginPage from './login-form'
+import ServerLoginPage from './page'
 import { ApiError } from '@/lib/api'
 
 // jsdom has no matchMedia; useTheme (via Alert) needs it during init
@@ -26,23 +27,24 @@ vi.mock('@/lib/api', async () => {
     }),
     login: vi.fn(),
     loginTwoFactor: vi.fn(),
-    navigation: { toLogin: vi.fn(), toHome: vi.fn() },
+    navigation: { toLogin: vi.fn(), toHome: vi.fn(), afterLogin: vi.fn() },
   }
 })
 
-import { login, loginTwoFactor, navigation } from '@/lib/api'
+import { getAuthStatus, login, loginTwoFactor, navigation } from '@/lib/api'
 
 const loginMock = vi.mocked(login)
 const loginTwoFactorMock = vi.mocked(loginTwoFactor)
-const toHomeMock = vi.mocked(navigation.toHome)
+const toHomeMock = vi.mocked(navigation.afterLogin)
 
 beforeEach(() => {
   loginMock.mockReset()
   loginTwoFactorMock.mockReset()
   toHomeMock.mockReset()
+  vi.mocked(getAuthStatus).mockResolvedValue({ mode: 'native', setup_required: false, authenticated: false })
 })
 
-afterEach(cleanup)
+afterEach(() => { cleanup(); vi.unstubAllEnvs() })
 
 function submitCredentials(email: string, password: string) {
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: email } })
@@ -51,11 +53,58 @@ function submitCredentials(email: string, password: string) {
 }
 
 describe('LoginPage', () => {
+  const destination = 'https://portal.example.test/projects?view=recent'
+
+  async function returnPage(returnTo: string | string[] = destination) {
+    vi.stubEnv('AUTH_LOGIN_RETURN_ORIGINS', '["https://portal.example.test"]')
+    return ServerLoginPage({ searchParams: Promise.resolve({ returnTo }) })
+  }
+
+  it('returns to the server-approved destination after password login', async () => {
+    loginMock.mockResolvedValue({ pending: false, pending_token: null, account: null })
+    render(await returnPage())
+    submitCredentials('admin@example.com', 'password')
+    await waitFor(() => expect(toHomeMock).toHaveBeenCalledWith(destination))
+  })
+
+  it('preserves the approved destination through the second factor', async () => {
+    loginMock.mockResolvedValue({ pending: true, pending_token: 'tok-return', account: null })
+    loginTwoFactorMock.mockResolvedValue({ pending: false, pending_token: null, account: null })
+    render(await returnPage())
+    submitCredentials('admin@example.com', 'password')
+    fireEvent.change(await screen.findByLabelText('Two-factor code'), { target: { value: '123456' } })
+    expect(toHomeMock).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }))
+    await waitFor(() => expect(toHomeMock).toHaveBeenCalledWith(destination))
+  })
+
+  it('returns an already authenticated visitor without asking for credentials', async () => {
+    vi.mocked(getAuthStatus).mockResolvedValue({ mode: 'native', setup_required: false, authenticated: true })
+    render(await returnPage())
+    await waitFor(() => expect(toHomeMock).toHaveBeenCalledWith(destination))
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['https://other.example.test/', ['https://portal.example.test/projects', 'https://other.example.test/']])('falls back to home when the server rejects the requested destination', async (returnTo) => {
+    loginMock.mockResolvedValue({ pending: false, pending_token: null, account: null })
+    render(await returnPage(returnTo))
+    submitCredentials('admin@example.com', 'password')
+    await waitFor(() => expect(toHomeMock).toHaveBeenCalledWith('/'))
+  })
+
+  it('reads the origin configuration for each request', async () => {
+    const allowed = await returnPage()
+    expect(allowed.props.returnTo).toBe(destination)
+    vi.stubEnv('AUTH_LOGIN_RETURN_ORIGINS', '[]')
+    const denied = await ServerLoginPage({ searchParams: Promise.resolve({ returnTo: destination }) })
+    expect(denied.props.returnTo).toBe('/')
+  })
+
   it('logs straight in for accounts without 2FA', async () => {
     loginMock.mockResolvedValue({ pending: false, pending_token: null, account: null })
     render(<LoginPage />)
     submitCredentials('admin@example.com', 'password')
-    await waitFor(() => expect(toHomeMock).toHaveBeenCalled())
+    await waitFor(() => expect(toHomeMock).toHaveBeenCalledWith('/'))
     expect(loginMock).toHaveBeenCalledWith('admin@example.com', 'password')
   })
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,118 +1,14 @@
-'use client'
+import { loginReturnDestination } from '@/lib/loginReturn'
+import LoginForm from './login-form'
 
-import { FormEvent, useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { Alert } from '@/components/Alert'
-import { ApiError, getAuthStatus, login, loginTwoFactor, navigation } from '@/lib/api'
+export const dynamic = 'force-dynamic'
 
-const inputClass =
-  'w-full px-3 py-2 text-sm rounded-[7px] bg-surface border border-border text-text-primary focus:outline-none'
-
-export default function LoginPage() {
-  const router = useRouter()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [pendingToken, setPendingToken] = useState<string | null>(null)
-  const [code, setCode] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
-
-  useEffect(() => {
-    getAuthStatus()
-      .then((status) => {
-        if (status.mode !== 'native' || status.authenticated) router.replace('/')
-        else if (status.setup_required) router.replace('/setup')
-      })
-      .catch(() => {})
-  }, [router])
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    setError(null)
-    setBusy(true)
-    try {
-      if (pendingToken) {
-        await loginTwoFactor(pendingToken, code)
-        navigation.toHome()
-        return
-      }
-      const result = await login(email, password)
-      if (result.pending && result.pending_token) {
-        setPendingToken(result.pending_token)
-        return
-      }
-      navigation.toHome()
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 401 && pendingToken) {
-        setError(err.message)
-        // an expired or exhausted pending token means starting over; a wrong
-        // code leaves the token usable, so stay on the code step
-        if (err.code === 'pending_login_invalid') {
-          setPendingToken(null)
-          setCode('')
-        }
-      } else {
-        setError(err instanceof ApiError ? err.message : 'login failed')
-      }
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  return (
-    <div className="max-w-sm mx-auto mt-16">
-      <div className="glass-card p-6">
-        <h1 className="text-base font-semibold text-text-primary mb-1">Log in</h1>
-        <p className="text-xs text-text-muted mb-4">
-          {pendingToken
-            ? 'Enter a code from your authenticator app, or a backup code.'
-            : 'Sign in to your Tracefinity account.'}
-        </p>
-        {error && (
-          <div className="mb-3">
-            <Alert variant="error">{error}</Alert>
-          </div>
-        )}
-        <form onSubmit={handleSubmit} className="space-y-3">
-          {pendingToken ? (
-            <input
-              className={inputClass}
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-              placeholder="123456"
-              autoComplete="one-time-code"
-              autoFocus
-              aria-label="Two-factor code"
-            />
-          ) : (
-            <>
-              <input
-                className={inputClass}
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="Email"
-                autoComplete="username"
-                required
-                aria-label="Email"
-              />
-              <input
-                className={inputClass}
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="Password"
-                autoComplete="current-password"
-                required
-                aria-label="Password"
-              />
-            </>
-          )}
-          <button type="submit" disabled={busy} className="btn-primary w-full py-2 text-sm">
-            {pendingToken ? 'Verify' : 'Log in'}
-          </button>
-        </form>
-      </div>
-    </div>
-  )
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ returnTo?: string | string[] }>
+}) {
+  const { returnTo } = await searchParams
+  const destination = loginReturnDestination(returnTo, process.env.AUTH_LOGIN_RETURN_ORIGINS)
+  return <LoginForm returnTo={destination} />
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -60,6 +60,10 @@ export const navigation = {
   toHome() {
     window.location.assign('/')
   },
+  // destination has already been checked by the login server page
+  afterLogin(destination: string) {
+    window.location.assign(destination)
+  },
 }
 
 function redirectToLogin() {

--- a/frontend/src/lib/loginReturn.test.ts
+++ b/frontend/src/lib/loginReturn.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { loginReturnDestination } from './loginReturn'
+
+describe('login return destination', () => {
+  it('preserves the path and query on an explicitly approved origin', () => {
+    expect(loginReturnDestination('https://portal.example.test/projects?view=recent', '["https://portal.example.test"]'))
+      .toBe('https://portal.example.test/projects?view=recent')
+  })
+  it.each([
+    undefined, null, ['https://portal.example.test/projects'], '',
+    'https://other.example.test/projects', 'https://portal.example.test.evil.test/',
+    'https://portal.example.test@evil.test/', 'https://user@portal.example.test/',
+    'http://portal.example.test/projects', 'https://portal.example.test:444/projects',
+    '//portal.example.test/projects', '/projects', 'javascript:alert(1)',
+    ' https://portal.example.test/', 'https://portal.example.test/\nprojects',
+    'https://portal.example.test\\@evil.test/', 'https://portal.example.test/' + 'x'.repeat(2048),
+  ])('uses home for an unapproved or malformed destination: %s', (value) => {
+    expect(loginReturnDestination(value, '["https://portal.example.test"]')).toBe('/')
+  })
+  it.each([undefined, '', 'bad json', '{}', '["*"]', '["https://portal.example.test/path"]', '["https://portal.example.test/?x=1"]'])('fails closed for invalid origin configuration: %s', (config) => {
+    expect(loginReturnDestination('https://portal.example.test/projects', config)).toBe('/')
+  })
+  it('allows a separately configured local HTTP origin and exact port', () => {
+    expect(loginReturnDestination('http://localhost:4002/projects', '["http://localhost:4002"]')).toBe('http://localhost:4002/projects')
+    expect(loginReturnDestination('http://localhost:4003/projects', '["http://localhost:4002"]')).toBe('/')
+  })
+})

--- a/frontend/src/lib/loginReturn.ts
+++ b/frontend/src/lib/loginReturn.ts
@@ -1,0 +1,24 @@
+// Only the server reads the origin list. Invalid or absent configuration keeps
+// the ordinary home-page destination; a query parameter cannot extend the list.
+export function loginReturnDestination(value: unknown, configuredOrigins?: string): string {
+  if (typeof value !== 'string' || value.length > 2048 || /[\u0000-\u0020\u007f\\]/.test(value)) return '/'
+  try {
+    const destination = new URL(value)
+    if (!['http:', 'https:'].includes(destination.protocol) || destination.username || destination.password) return '/'
+    const origins: unknown = JSON.parse(configuredOrigins || '[]')
+    if (!Array.isArray(origins)) return '/'
+    const approved = origins.some((entry: unknown) => {
+      if (typeof entry !== 'string') return false
+      try {
+        const origin = new URL(entry)
+        return origin.origin === destination.origin &&
+          entry === origin.origin && ['http:', 'https:'].includes(origin.protocol)
+      } catch {
+        return false
+      }
+    })
+    return approved ? destination.href : '/'
+  } catch {
+    return '/'
+  }
+}


### PR DESCRIPTION
## Summary

- Preserve an explicitly approved return URL through password login, two-factor login, and an already authenticated visit. The frontend server reads `AUTH_LOGIN_RETURN_ORIGINS` at runtime; an empty list or invalid destination keeps the existing `/` fallback.

## Test evidence

- Backend `python -m pytest -q` using the existing project virtualenv: 754 passed.
- `pnpm --dir frontend test`: 218 passed, including server-page validation and rendered login form flows.
- `make lint`: passed, with 9 existing frontend warnings; TypeScript passed.
- The login form appearance is unchanged. Tests cover password and two-factor return navigation, existing sessions, rejected destinations, and request-time configuration changes.
